### PR TITLE
Update submissions.js to support "details" parameter of {{Afc decline}}.

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1964,7 +1964,7 @@
 						'$2': afchSubmission.shortTitle,
 						'$3': declineReason === 'cv' ? 'yes' : 'no',
 						'$4': declineReason,
-						'$5': typeof newParams['3'] != 'undefined' ? newParams['3'] : ''
+						'$5': newParams['3'] || ''
 					} );
 
 					if ( teahouse ) {


### PR DESCRIPTION
Support "details" parameter of {{Afc decline}}.

A recent change started supporting the "reason" tag in {{Afc decline}}, but this didn't work with reasons such as a custom reason or the "dup" reason that require a second parameter. I have changed {{Afc decline}} to support a "details" parameter that passes a second parameter to {{AFC submission/comments}}. This parameter is already collected by the AFCH script for use in {{AFC submission}}, but needs to be passed to {{Afc decline}} as well.

As a disclaimer, I haven't tested this patch.
