### PR TITLE
Suggest current draft title when article exists

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1690,7 +1690,7 @@
 						},
 
 						exists: function () {
-							updateTextfield( 'Title of existing article', 'Chocolate chip cookie' );
+							updateTextfield( 'Title of existing article', mw.config.get( 'wgTitle' ).split('/').pop() );
 						},
 
 						plot: function () {


### PR DESCRIPTION
When an article exists, suggest the title of the current draft instead of "chocolate chip cookies". For "Draft:Example", it would suggest "Example", and for "User:Example/Title" or "Wikipedia talk:Articles for creation/Title" it would suggest "Title".
