### PR TITLE
Added links to random submissions

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -461,37 +461,6 @@
 	};
 
 	/**
-	 * Gets the next submission in the queue (i.e. the oldest one).
-	 * @param {bool} older Whether to get the oldest pending submission instead of the newest one.
-	 * @return {$.Deferred} resolves with API call
-	 */
-	AFCH.Submission.prototype.getNextSubmission = function ( older ) {
-		var deferred = $.Deferred(),
-			request = {
-				action: 'query',
-				list: 'categorymembers',
-				cmtitle: 'Category:Pending AfC submissions',
-				cmnamespace: 5,
-				cmtype: 'page',
-				cmlimit: 1,
-				cmsort: 'sortkey',
-				cmdir: older ? 'desc' : 'asc',
-				cmstartsortkey: 'P' + ( ( this.templates.length && this.templates[0].timestamp ) / 100 ) + ( older ? 0 : 1 )
-			};
-
-		AFCH.api.get( request )
-			.done( function ( data ) {
-				if ( data.query.categorymembers && data.query.categorymembers.length && data.query.categorymembers[0].title ) {
-					deferred.resolve( data.query.categorymembers[0].title );
-				} else {
-					deferred.reject( data );
-				}
-			} );
-
-		return deferred;
-	};
-
-	/**
 	 * Represents text of an AfC submission
 	 * @param {[type]} text [description]
 	 */
@@ -1214,10 +1183,6 @@
 				'$2': AFCH.makeLinkElementToPage( 'Special:RandomInCategory/AfC pending submissions by age/0 days ago', 'GFOO submission' ),
 				'$3': AFCH.makeLinkElementToPage( 'Special:RandomInCategory/Category:AfC submissions by age/Very old', 'very old submission' )
 			} );
-
-			//afchSubmission.getNextSubmission().done( function ( title ) {
-			//	new AFCH.status.Element( 'Continue to next submission, $1 &raquo;', { '$1': AFCH.makeLinkElementToPage( title ) } );
-			//} );
 
 			// Also, automagically reload the page in place
 			$( '#mw-content-text' ).load( AFCH.consts.pagelink + ' #mw-content-text', function () {


### PR DESCRIPTION
In lieu of actually fetching the pages, we can just use Special:RandomInCategory.

I've included 3 categories here (general, very old, and GFOO); reading the WT:WPAFC page, it seems like those three are the most commonly used.

Fixes #27.
