### PR TITLE
Notify User if the talk page exists

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1585,13 +1585,12 @@
 						$submitButton
 							.addClass( 'disabled' )
 							.text( buttonText );
-							return;
 					} );
 				} );
 
-					// Update titleStatus
-					$afch.find( '#newTitle' ).trigger( 'keyup' );
-				} );
+				// Update titleStatus
+				$afch.find( '#newTitle' ).trigger( 'keyup' );
+			} );
 			addFormSubmitHandler( handleAccept );
 		} );
 	}


### PR DESCRIPTION
Upon typing a title, the plugin will check for the main page, the talk
page, a draft page in the format 'draft:title' and the talk page for the
draft, in that order of importance

Known issues: The error message flashes a little when the name is being
typed, due to the different namespaces being checked.

http://www.google-melange.com/gci/task/view/google/gci2014/5877487489777664
https://github.com/WPAFC/afch-rewrite/issues/26
