### PR TITLE
Update biography DEFAULTSORT autofill to work with paranthetical disambiguation

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
   },
   "jest": {
     "testEnvironment": "jsdom",
-    "testMatch": [ "**/__tests__/**/test-*.[jt]s?(x)", "**/?(*.)+(spec|test).[jt]s?(x)" ]
+    "testMatch": [
+      "**/__tests__/**/test-*.[jt]s?(x)",
+      "**/?(*.)+(spec|test).[jt]s?(x)"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,9 +37,6 @@
   },
   "jest": {
     "testEnvironment": "jsdom",
-    "testMatch": [
-      "**/__tests__/**/test-*.[jt]s?(x)",
-      "**/?(*.)+(spec|test).[jt]s?(x)"
-    ]
+    "testMatch": [ "**/__tests__/**/test-*.[jt]s?(x)", "**/?(*.)+(spec|test).[jt]s?(x)" ]
   }
 }

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1705,7 +1705,8 @@
 				function prefillBiographyDetails() {
 					var titleParts;
 
-					// Prefill `LastName, FirstName` for Biography if the page title is two words and
+					// Prefill `LastName, FirstName` for Biography if the page title is two words
+					// after removing any trailing parantheticals (likely disambiguation), and
 					// therefore probably safe to asssume in a `FirstName LastName` format.
 					title = afchSubmission.shortTitle.replace(/ \([\s\S]*?\)$/g, '')
 					titleParts = title.split(' ');

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1706,10 +1706,10 @@
 					var titleParts;
 
 					// Prefill `LastName, FirstName` for Biography if the page title is two words
-					// after removing any trailing parantheticals (likely disambiguation), and
+					// after removing any trailing parentheticals (likely disambiguation), and
 					// therefore probably safe to asssume in a `FirstName LastName` format.
-					title = afchSubmission.shortTitle.replace(/ \([\s\S]*?\)$/g, '')
-					titleParts = title.split(' ');
+					var title = afchSubmission.shortTitle.replace( / \([\s\S]*?\)$/g, '' );
+					titleParts = title.split( ' ' );
 					if ( titleParts.length === 2 ) {
 						$afch.find( '#subjectName' ).val( titleParts[ 1 ] + ', ' + titleParts[ 0 ] );
 					}

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1707,7 +1707,8 @@
 
 					// Prefill `LastName, FirstName` for Biography if the page title is two words and
 					// therefore probably safe to asssume in a `FirstName LastName` format.
-					titleParts = afchSubmission.shortTitle.split( ' ' );
+					title = afchSubmission.shortTitle.replace(/ \([\s\S]*?\)$/g, '')
+					titleParts = title.split(' ');
 					if ( titleParts.length === 2 ) {
 						$afch.find( '#subjectName' ).val( titleParts[ 1 ] + ', ' + titleParts[ 0 ] );
 					}


### PR DESCRIPTION
Very small PR just to make sure I understand how everything works before I try to handle any of the outstanding issues: when accepting a biography, autofills name when there is a parenthetical disambiguation and otherwise the title looks to be Firstname Lastname. (Also, my IDE took umbrage with package.json's testMatch having two entries on one line and decided to fix it for me, which I haven't undone because it seems like a reasonable formatting change. Happy to undo it if that's a problem.)

![Screenshot from 2022-04-21 21-07-26](https://user-images.githubusercontent.com/60860948/164576857-79d76ce7-d5a5-4681-a657-803ed4318ed9.png)