### PR TITLE
Add G11 and G3 CSD options

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1961,6 +1961,10 @@
 							updateTextfield( 'Title of existing related article, if one exists', 'Charlie and the Chocolate Factory', candidateDupeName, pos );
 						},
 
+						adv: function ( pos ) {
+							$afch.add('#csdWrapper').removeClass('hidden');
+						},
+
 						// Custom decline rationale
 						reason: function () {
 							$afch.find( '#declineTextarea' )
@@ -2454,6 +2458,11 @@
 			}
 		}
 
+		// Excessive advertisment/promotion gets {{db-g11}}'d
+		if ( ( declineReason === 'adv' || declineReason2 === 'adv' ) && data.csdSubmission ) {
+			text.prepend('{{db-g11}}\n');
+		}
+
 		if ( !isDecline ) {
 			newParams.reject = 'yes';
 		}
@@ -2564,12 +2573,21 @@
 
 		// Log CSD if necessary
 		if ( data.csdSubmission ) {
+
+			var csdReason = ''
+			if (declineReason === 'cv') {
+				csdReason = '[[WP:G12]] ({{tl|db-copyvio}})';
+			} else if ( declineReason === 'adv' ) {
+				csdReason = '[[WP:G11]] ({{tl|db-spam}})';
+			} else {
+				csdReason = '{{tl|db-reason}} ([[WP:AFC|Articles for creation]])';
+			}
+
 			// FIXME: Only get submitter if needed...?
 			afchSubmission.getSubmitter().done( function ( submitter ) {
 				AFCH.actions.logCSD( {
 					title: afchPage.rawTitle,
-					reason: declineReason === 'cv' ? '[[WP:G12]] ({{tl|db-copyvio}})' :
-						'{{tl|db-reason}} ([[WP:AFC|Articles for creation]])',
+					reason: csdReason,
 					usersNotified: data.notifyUser ? [ submitter ] : []
 				} );
 			} );

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1969,6 +1969,10 @@
 							$afch.add('#csdWrapper').removeClass('hidden');
 						},
 
+						joke: function () {
+							$afch.add('#csdWrapper').removeClass('hidden');
+						},
+						
 						// Custom decline rationale
 						reason: function () {
 							$afch.find( '#declineTextarea' )
@@ -2439,31 +2443,35 @@
 			afchSubmission.addNewComment( data.rejectTextarea );
 		}
 
-		// Copyright violations get {{db-g12}}'d, excessive advertisment gets {{db-g11}}'d, vandalism gets {{db-g3}}'d
-		if ( ( declineReason === 'cv' || declineReason2 === 'cv' ) && data.csdSubmission ) {
-			var cvUrls = data.cvUrlTextarea.split( '\n' ).slice( 0, 3 ),
-				urlParam = '';
+		// Copyright violations get {{db-g12}}'d, excessive advertisment gets {{db-g11}}'d, vandalism and hoaxes get {{db-g3}}'d
+		if ( data.csdSubmission ) {
+			if (declineReason === 'cv' || declineReason2 === 'cv') {
+				var cvUrls = data.cvUrlTextarea.split('\n').slice(0, 3),
+					urlParam = '';
 
-			// Build url param for db-g12 template
-			urlParam = cvUrls[ 0 ];
-			if ( cvUrls.length > 1 ) {
-				urlParam += '|url2=' + cvUrls[ 1 ];
-				if ( cvUrls.length > 2 ) {
-					urlParam += '|url3=' + cvUrls[ 2 ];
+				// Build url param for db-g12 template
+				urlParam = cvUrls[0];
+				if (cvUrls.length > 1) {
+					urlParam += '|url2=' + cvUrls[1];
+					if (cvUrls.length > 2) {
+						urlParam += '|url3=' + cvUrls[2];
+					}
 				}
-			}
-			text.prepend( '{{db-g12|url=' + urlParam + ( afchPage.additionalData.revId ? '|oldid=' + afchPage.additionalData.revId : '' ) + '}}\n' );
+				text.prepend('{{db-g12|url=' + urlParam + (afchPage.additionalData.revId ? '|oldid=' + afchPage.additionalData.revId : '') + '}}\n');
 
-			// Include the URLs in the decline template
-			if ( declineReason === 'cv' ) {
-				newParams[ '3' ] = cvUrls.join( ', ' );
-			} else {
-				newParams.details2 = cvUrls.join( ', ' );
-			}
-		} else if ( ( declineReason === 'adv' || declineReason2 === 'adv' ) && data.csdSubmission ) {
-			text.prepend('{{db-g11}}\n');
-		} else	if ( ( declineReason === 'van' || declineReason2 === 'van') && data.csdSubmission ) {
-			text.prepend('{{db-g3}}\n');
+				// Include the URLs in the decline template
+				if (declineReason === 'cv') {
+					newParams['3'] = cvUrls.join(', ');
+				} else {
+					newParams.details2 = cvUrls.join(', ');
+				}
+			} else if (declineReason === 'adv' || declineReason2 === 'adv') {
+				text.prepend('{{db-g11}}\n');
+			} else if (declineReason === 'van' || declineReason2 === 'van' 
+					|| declineReason === 'joke' || declineReason2 === 'joke') {
+				text.prepend('{{db-g3}}\n');
+			} 
+
 		}
 
 		if ( !isDecline ) {
@@ -2584,6 +2592,8 @@
 				csdReason = '[[WP:G11]] ({{tl|db-spam}})';
 			} else if ( declineReason === 'van' || declineReason2 === 'van') {
 				csdReason = '[[WP:G3]] ({{tl|db-vandalism}})';
+			} else if ( declineReason === 'joke' || declineReason2 === 'joke') {
+				csdReason = '[[WP:G3]] ({{tl|db-hoax}})';
 			} else {
 				csdReason = '{{tl|db-reason}} ([[WP:AFC|Articles for creation]])';
 			}

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1905,7 +1905,7 @@
 					candidateDupeName = ( afchSubmission.shortTitle !== 'sandbox' ) ? afchSubmission.shortTitle : '',
 					prevDeclineComment = $afch.find( '#declineTextarea' ).val(),
 					declineHandlers = {
-						cv: function ( pos ) {
+						cv: function ( ) {
 							$afch.find( '#cvUrlWrapper' ).removeClass( 'hidden' );
 							$afch.add( '#csdWrapper' ).removeClass( 'hidden' );
 
@@ -1961,7 +1961,11 @@
 							updateTextfield( 'Title of existing related article, if one exists', 'Charlie and the Chocolate Factory', candidateDupeName, pos );
 						},
 
-						adv: function ( pos ) {
+						adv: function () {
+							$afch.add('#csdWrapper').removeClass('hidden');
+						},
+
+						van: function () {
 							$afch.add('#csdWrapper').removeClass('hidden');
 						},
 
@@ -2435,7 +2439,7 @@
 			afchSubmission.addNewComment( data.rejectTextarea );
 		}
 
-		// Copyright violations get {{db-g12}}'d as well
+		// Copyright violations get {{db-g12}}'d, excessive advertisment gets {{db-g11}}'d, vandalism gets {{db-g3}}'d
 		if ( ( declineReason === 'cv' || declineReason2 === 'cv' ) && data.csdSubmission ) {
 			var cvUrls = data.cvUrlTextarea.split( '\n' ).slice( 0, 3 ),
 				urlParam = '';
@@ -2456,11 +2460,10 @@
 			} else {
 				newParams.details2 = cvUrls.join( ', ' );
 			}
-		}
-
-		// Excessive advertisment/promotion gets {{db-g11}}'d
-		if ( ( declineReason === 'adv' || declineReason2 === 'adv' ) && data.csdSubmission ) {
+		} else if ( ( declineReason === 'adv' || declineReason2 === 'adv' ) && data.csdSubmission ) {
 			text.prepend('{{db-g11}}\n');
+		} else	if ( ( declineReason === 'van' || declineReason2 === 'van') && data.csdSubmission ) {
+			text.prepend('{{db-g3}}\n');
 		}
 
 		if ( !isDecline ) {
@@ -2575,10 +2578,12 @@
 		if ( data.csdSubmission ) {
 
 			var csdReason = ''
-			if (declineReason === 'cv') {
+			if (declineReason === 'cv' || declineReason2 === 'cv') {
 				csdReason = '[[WP:G12]] ({{tl|db-copyvio}})';
-			} else if ( declineReason === 'adv' ) {
+			} else if ( declineReason === 'adv' || declineReason2 === 'adv') {
 				csdReason = '[[WP:G11]] ({{tl|db-spam}})';
+			} else if ( declineReason === 'van' || declineReason2 === 'van') {
+				csdReason = '[[WP:G3]] ({{tl|db-vandalism}})';
 			} else {
 				csdReason = '{{tl|db-reason}} ([[WP:AFC|Articles for creation]])';
 			}


### PR DESCRIPTION
Addresses #92 and #91. For drafts declined as vandalism/BLP violations, it will _not_ provide the option to tag with G10 (attack page) as someone asked in #91.