### PR TITLE
handleSubmit: add "unsubmitted" as an option

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -2626,9 +2626,9 @@
 		}
 
 		submitter.done( function ( submitter ) {
-			var params = submitter ? { u: submitter } : {};
-			var status = !submitter ? 't' : '';
-			var makeTimestamp = Boolean( submitter );
+			var params = ( submitter === '' ) ? {} : { u: submitter };
+			var status = ( submitter === '' ) ? 't' : '';
+			var makeTimestamp = ( submitter !== '' );
 
 			afchSubmission.setStatus( status, params, makeTimestamp );
 

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -2626,9 +2626,17 @@
 		}
 
 		submitter.done( function ( submitter ) {
-			var params = ( submitter === '' ) ? {} : { u: submitter };
-			var status = ( submitter === '' ) ? 't' : '';
-			var makeTimestamp = ( submitter !== '' );
+			var params, status, makeTimestamp;
+			var submitTypeUnsubmitted = ( submitter === '' );
+			if ( submitTypeUnsubmitted ) {
+				status = 't';
+				params = {};
+				makeTimestamp = false;
+			} else {
+				status = '';
+				params = { u: submitter };
+				makeTimestamp = true;
+			}
 
 			afchSubmission.setStatus( status, params, makeTimestamp );
 

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -2613,13 +2613,21 @@
 			afchPage.getCreator().done( function ( user ) {
 				submitter.resolve( user );
 			} );
+		} else if ( submitType === 'unsubmitted' ) {
+			submitter.resolve( '' );
 		} else {
 			// Custom selected submitter
 			submitter.resolve( data.submitType );
 		}
 
 		submitter.done( function ( submitter ) {
-			afchSubmission.setStatus( '', { u: submitter } );
+			var params = { u: submitter };
+			var hasNoSubmitter = submitter === '';
+			if ( hasNoSubmitter ) {
+				params[ '1' ] = 'T'; // unsubmitted
+			}
+
+			afchSubmission.setStatus( '', params );
 
 			text.updateAfcTemplates( afchSubmission.makeWikicode() );
 			text.cleanUp();

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -365,11 +365,15 @@
 	 * Sets the submission status
 	 *
 	 * @param {string} newStatus status to set, 'd'|'t'|'r'|''
-	 * @param {params} optional; params to add to the template whose status was set
 	 * @param newParams
+	 * @param {bool} [makeTimestamp=true]
 	 * @return {bool} success
 	 */
-	AFCH.Submission.prototype.setStatus = function ( newStatus, newParams ) {
+	AFCH.Submission.prototype.setStatus = function ( newStatus, newParams, makeTimestamp ) {
+		if ( makeTimestamp === undefined ) {
+			makeTimestamp = true;
+		}
+
 		var relevantTemplate = this.templates[ 0 ];
 
 		if ( [ 'd', 't', 'r', '' ].indexOf( newStatus ) === -1 ) {
@@ -390,7 +394,7 @@
 			this.addNewTemplate( {
 				status: newStatus,
 				params: newParams
-			} );
+			}, makeTimestamp );
 		} else {
 			// Just modify the template at the top of the stack
 			relevantTemplate.status = newStatus;
@@ -413,11 +417,12 @@
 	 *                      - status (default: '')
 	 *                      - timestamp (default: '{{subst:REVISIONTIMESTAMP}}')
 	 *                      - params (default: {})
+	 * @param {bool} makeTimestamp
 	 */
-	AFCH.Submission.prototype.addNewTemplate = function ( data ) {
+	AFCH.Submission.prototype.addNewTemplate = function ( data, makeTimestamp ) {
 		this.templates.unshift( $.extend( /* deep */ true, {
 			status: '',
-			timestamp: '{{subst:REVISIONTIMESTAMP}}',
+			timestamp: makeTimestamp ? '{{subst:REVISIONTIMESTAMP}}' : '',
 			params: {
 				ns: mw.config.get( 'wgNamespaceNumber' )
 			}
@@ -2623,8 +2628,9 @@
 		submitter.done( function ( submitter ) {
 			var params = submitter ? { u: submitter } : {};
 			var status = ( submitter === '' ) ? 't' : '';
+			var makeTimestamp = submitter !== '';
 
-			afchSubmission.setStatus( status, params );
+			afchSubmission.setStatus( status, params, makeTimestamp );
 
 			text.updateAfcTemplates( afchSubmission.makeWikicode() );
 			text.cleanUp();

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -2621,13 +2621,10 @@
 		}
 
 		submitter.done( function ( submitter ) {
-			var params = { u: submitter };
-			var hasNoSubmitter = submitter === '';
-			if ( hasNoSubmitter ) {
-				params[ '1' ] = 'T'; // unsubmitted
-			}
+			var params = submitter ? { u: submitter } : {};
+			var status = ( submitter === '' ) ? 't' : '';
 
-			afchSubmission.setStatus( '', params );
+			afchSubmission.setStatus( status, params );
 
 			text.updateAfcTemplates( afchSubmission.makeWikicode() );
 			text.cleanUp();

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -365,7 +365,7 @@
 	 * Sets the submission status
 	 *
 	 * @param {string} newStatus status to set, 'd'|'t'|'r'|''
-	 * @param newParams
+	 * @param {Object} newParams
 	 * @param {bool} [makeTimestamp=true]
 	 * @return {bool} success
 	 */
@@ -2627,8 +2627,8 @@
 
 		submitter.done( function ( submitter ) {
 			var params = submitter ? { u: submitter } : {};
-			var status = ( submitter === '' ) ? 't' : '';
-			var makeTimestamp = submitter !== '';
+			var status = !submitter ? 't' : '';
+			var makeTimestamp = Boolean( submitter );
 
 			afchSubmission.setStatus( status, params, makeTimestamp );
 

--- a/src/templates/tpl-submissions.html
+++ b/src/templates/tpl-submissions.html
@@ -337,6 +337,7 @@
 			<option value="creator">Page creator</option>
 			<option value="self">Yourself</option>
 			<option value="other">Someone else</option>
+			<option value="unsubmitted">Unsubmitted</option>
 		</select>
 
 		<div id="submitterNameWrapper" class="hidden">


### PR DESCRIPTION
Fixes #240

Adds an "Unsubmitted" option to the combo box in the Submit dialog. Generates the following Wikicode: `{{AFC submission|t|ns=118|ts=}}`.

Primefac objects below, but in the bug report appears to change his mind. He brings up a good point that this should not generate a timestamp, so I have made sure my code does not generate a timestamp.

The use case is a page in the Draft namespace that does not have any AFC template at all. This lets you add the AFC submission template, but in an unsubmitted state, which is useful sometimes.

<img width="1034" alt="image" src="https://user-images.githubusercontent.com/79697282/179371459-30d2c144-2c52-4a4f-9fb3-f7ca745fa44e.png">