### PR TITLE
fix regex catastrophic backtracking

### DIFF
--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -1598,21 +1598,14 @@
 			var count = lines.length;
 			for ( i = count - 1; i >= 0; i-- ) {
 				var line = lines[ i ];
-
 				var isWhitespace = line.match( /^\s*$/ );
-				if ( isWhitespace ) {
-					linesToKeep.push( line );
-					continue;
-				}
-
 				var isCategory = line.match( /^\s*\[\[:?Category:/i );
-				if ( isCategory ) {
+				var isHeading = line.match( /^==[^=]+==$/i );
+
+				if ( isWhitespace || isCategory ) {
 					linesToKeep.push( line );
 					continue;
-				}
-
-				var isHeading = line.match( /^==[^=]+==$/i );
-				if ( isHeading ) {
+				} else if ( isHeading ) {
 					break;
 				}
 

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -1579,6 +1579,18 @@
 		},
 
 		/**
+		 * Remove empty section at the end (caused by "Resubmit" button on "declined" template)
+		 * Section may have categories after it - keep them there
+		 *
+		 * @param {string} wikicode
+		 */
+		removeEmptySectionAtEnd: function ( wikicode ) {
+			wikicode = wikicode.replace( /(\n)==[^=]+==\n\s*?(\[\[Category:|$)/i, '$1$2' );
+			wikicode = wikicode.replace( /\n\n$/, '\n' );
+			return wikicode;
+		},
+
+		/**
 		 * Returns the relative time that has elapsed between an oldDate and a nowDate
 		 *
 		 * @param {Date|string} old (if it is a string it will be assumed to be a

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -1579,8 +1579,9 @@
 		},
 
 		/**
-		 * Remove empty section at the end (caused by "Resubmit" button on "declined" template)
-		 * Section may have categories after it - keep them there
+		 * Remove empty section at the end of the draft. Empty sections at the end of drafts
+		 * frequently happen because of how the "Resubmit" button on the "declined" template
+		 * works. The empty section may have categories after it - keep them there.
 		 *
 		 * @param {string} wikicode
 		 */

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -1585,9 +1585,12 @@
 		 * @param {string} wikicode
 		 */
 		removeEmptySectionAtEnd: function ( wikicode ) {
-			wikicode = wikicode.replace( /(\n)==[^=]+==\n\s*?(\[\[Category:|$)/i, '$1$2' );
-			wikicode = wikicode.replace( /\n\n$/, '\n' );
-			return wikicode;
+			result = wikicode.replace( /(\n)==[^=]+==\n\s*?(\[\[Category:|$)/i, '$1$2' );
+			var headingWasRemoved = result !== wikicode;
+			if ( headingWasRemoved ) {
+				result = result.replace( /\n\n$/, '\n' );
+			}
+			return result;
 		},
 
 		/**

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -1585,7 +1585,7 @@
 		 * @param {string} wikicode
 		 */
 		removeEmptySectionAtEnd: function ( wikicode ) {
-			result = wikicode.replace( /(\n)==[^=]+==\n\s*?(\[\[Category:|$)/i, '$1$2' );
+			result = wikicode.replace( /(\n)==[^=]+==\n\s*?(\[\[:?Category:|$)/i, '$1$2' );
 			var headingWasRemoved = result !== wikicode;
 			if ( headingWasRemoved ) {
 				result = result.replace( /\n\n$/, '\n' );

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -1626,7 +1626,7 @@
 
 			wikicode = lines.join( '\n' );
 
-			// The old algorithm had some quirks related to adding and removing \n. Mimic the old algorithm, for backwards compatibility.
+			// The old algorithm had some quirks related to adding and removing \n. Mimic the old algorithm for now, so that unit tests pass and users don't have to get used to new behavior.
 			if ( wikicode.match( /\n\n$/ ) ) {
 				wikicode = wikicode.slice( 0, -1 );
 			}

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -1626,12 +1626,10 @@
 
 			wikicode = lines.join( '\n' );
 
-			// The old algorithm removed one \n from the end. To keep backwards compatibility, will copy that here.
+			// The old algorithm had some quirks related to adding and removing \n. Mimic the old algorithm, for backwards compatibility.
 			if ( wikicode.match( /\n\n$/ ) ) {
 				wikicode = wikicode.slice( 0, -1 );
 			}
-
-			// The old alg also removed one \n if multiple \n occurred between text and the categories. Keeping for backwards compatibility.
 			wikicode = wikicode.replace( /\n(\n\n\[\[:?Category:)/i, '$1' );
 
 			return wikicode;

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -555,7 +555,7 @@
 
 		// Remove empty section at the end (caused by "Resubmit" button on "declined" template)
 		// Section may have categories after it - keep them there
-		text = text.replace( /\n+==.+?==((?:\[\[:?Category:.+?\]\]|\s+)*)$/, '$1' );
+		text = AFCH.removeEmptySectionAtEnd( text );
 
 		// Assemble a master regexp and remove all now-unneeded comments (commentsToRemove)
 		commentRegex = new RegExp( '<!-{2,}\\s*(' + commentsToRemove.join( '|' ) + ')\\s*-{2,}>', 'gi' );

--- a/tests/scaffold.js
+++ b/tests/scaffold.js
@@ -21,7 +21,13 @@ mw.user = {
 };
 
 mw.loader = {
-	using: function () { return { then: function ( callback ) { callback(); } }; }
+	using: function () {
+		return {
+			then: function ( callback ) {
+				callback();
+			}
+		};
+	}
 };
 
 var basePageHtml = fs.readFileSync( './tests/test-frame.html' ).toString();

--- a/tests/test-core.js
+++ b/tests/test-core.js
@@ -44,6 +44,24 @@ describe( 'AFCH.removeEmptySectionAtEnd', function () {
 		expect( output ).toBe( 'Test\n\n==Test2==\nMore test text\n\n== Test 3 ==\nYour text here.\n[[Category:Test]]\n' );
 	} );
 
+	it( '1 heading, 1 category, 1 heading, 1 empty heading', function () {
+		var wikicode = 'Test\n\n==Test2==\nMore test text\n\n[[Category:Test]]\n\n== Test 3 ==\nYour text here.\n\n== Test 4 ==\n';
+		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+		expect( output ).toBe( 'Test\n\n==Test2==\nMore test text\n\n[[Category:Test]]\n\n== Test 3 ==\nYour text here.\n' );
+	} );
+
+	it( '1 heading, 2 categories, 1 heading, 1 empty heading', function () {
+		var wikicode = 'Test\n\n==Test2==\nMore test text\n\n[[Category:Test]]\n[[Category:Test2]]\n\n== Test 3 ==\nYour text here.\n\n== Test 4 ==\n';
+		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+		expect( output ).toBe( 'Test\n\n==Test2==\nMore test text\n\n[[Category:Test]]\n[[Category:Test2]]\n\n== Test 3 ==\nYour text here.\n' );
+	} );
+
+	it( '1 empty heading, 2 categories, 1 heading, 1 empty heading', function () {
+		var wikicode = 'Test\n\n==Test2==\n[[Category:Test]]\n[[Category:Test2]]\n\n== Test 3 ==\nYour text here.\n\n== Test 4 ==\n';
+		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+		expect( output ).toBe( 'Test\n\n==Test2==\n[[Category:Test]]\n[[Category:Test2]]\n\n== Test 3 ==\nYour text here.\n' );
+	} );
+
 	it( 'one heading without body text', function () {
 		var wikicode = 'Test\n\n==Test2==\n';
 		var output = AFCH.removeEmptySectionAtEnd( wikicode );

--- a/tests/test-core.js
+++ b/tests/test-core.js
@@ -62,6 +62,12 @@ describe( 'AFCH.removeEmptySectionAtEnd', function () {
 		expect( output ).toBe( 'Test\n\n==Test2==\n\n[[Category:Test]]\n' );
 	} );
 
+	it( 'disabled category', function () {
+		var wikicode = 'Test\n\n==Test2==\n\n== Test 3 ==\n\n[[:Category:Test]]\n';
+		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+		expect( output ).toBe( 'Test\n\n==Test2==\n\n[[:Category:Test]]\n' );
+	} );
+
 	it( 'two headings without body text and with two categories #1', function () {
 		var wikicode = 'Test\n\n==Test2==\n\n== Test 3 ==\n\n[[Category:Test]]\n[[Category:Test2]]\n';
 		var output = AFCH.removeEmptySectionAtEnd( wikicode );

--- a/tests/test-core.js
+++ b/tests/test-core.js
@@ -80,6 +80,12 @@ describe( 'AFCH.removeEmptySectionAtEnd', function () {
 		expect( output ).toBe( 'Test\n\n==Test2==\n\n[[Category:Test]]\n\n [[Category:Test2]]\n' );
 	} );
 
+	it( 'don\'t trim if no heading was deleted', function () {
+		var wikicode = 'Test\n\n';
+		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+		expect( output ).toBe( 'Test\n\n' );
+	} );
+
 	// Catastrophic backtracking occurs if this test causes the test suite to get stuck for a long time
 	it( 'should not cause regex catastrophic backtracking', function () {
 		var wikicode = '{{AFC submission}}\n==A==\n                                                                                                             \nB';

--- a/tests/test-core.js
+++ b/tests/test-core.js
@@ -18,3 +18,72 @@ describe( 'AFCH', function () {
 describe( 'AFCH.Page', function () {
 	// FIXME...
 } );
+
+describe( 'AFCH.removeEmptySectionAtEnd', function () {
+	it( 'no headings', function () {
+		var wikicode = 'Test';
+		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+		expect( output ).toBe( 'Test' );
+	} );
+
+	it( 'one heading with body text', function () {
+		var wikicode = 'Test\n\n==Test2==\nMore test text\n';
+		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+		expect( output ).toBe( 'Test\n\n==Test2==\nMore test text\n' );
+	} );
+
+	it( 'two headings with body text', function () {
+		var wikicode = 'Test\n\n==Test2==\nMore test text\n\n== Test 3 ==\nYour text here.\n';
+		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+		expect( output ).toBe( 'Test\n\n==Test2==\nMore test text\n\n== Test 3 ==\nYour text here.\n' );
+	} );
+
+	it( 'two headings with body text and with categories', function () {
+		var wikicode = 'Test\n\n==Test2==\nMore test text\n\n== Test 3 ==\nYour text here.\n[[Category:Test]]\n';
+		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+		expect( output ).toBe( 'Test\n\n==Test2==\nMore test text\n\n== Test 3 ==\nYour text here.\n[[Category:Test]]\n' );
+	} );
+
+	it( 'one heading without body text', function () {
+		var wikicode = 'Test\n\n==Test2==\n';
+		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+		expect( output ).toBe( 'Test\n' );
+	} );
+
+	it( 'two headings without body text', function () {
+		var wikicode = 'Test\n\n==Test2==\n\n== Test 3 ==\n';
+		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+		expect( output ).toBe( 'Test\n\n==Test2==\n' );
+	} );
+
+	it( 'two headings without body text and with one category', function () {
+		var wikicode = 'Test\n\n==Test2==\n\n== Test 3 ==\n\n[[Category:Test]]\n';
+		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+		expect( output ).toBe( 'Test\n\n==Test2==\n\n[[Category:Test]]\n' );
+	} );
+
+	it( 'two headings without body text and with two categories #1', function () {
+		var wikicode = 'Test\n\n==Test2==\n\n== Test 3 ==\n\n[[Category:Test]]\n[[Category:Test2]]\n';
+		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+		expect( output ).toBe( 'Test\n\n==Test2==\n\n[[Category:Test]]\n[[Category:Test2]]\n' );
+	} );
+
+	it( 'two headings without body text and with two categories #2', function () {
+		var wikicode = 'Test\n\n==Test2==\n\n== Test 3 ==\n\n[[Category:Test]]\n\n[[Category:Test2]]\n';
+		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+		expect( output ).toBe( 'Test\n\n==Test2==\n\n[[Category:Test]]\n\n[[Category:Test2]]\n' );
+	} );
+
+	it( 'two headings without body text and with two categories #3', function () {
+		var wikicode = 'Test\n\n==Test2==\n\n== Test 3 ==\n\n[[Category:Test]]\n\n [[Category:Test2]]\n';
+		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+		expect( output ).toBe( 'Test\n\n==Test2==\n\n[[Category:Test]]\n\n [[Category:Test2]]\n' );
+	} );
+
+	// Catastrophic backtracking occurs if this test causes the test suite to get stuck for a long time
+	it( 'should not cause regex catastrophic backtracking', function () {
+		var wikicode = '{{AFC submission}}\n==A==\n                                                                                                             \nB';
+		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+		expect( output ).toBe( '{{AFC submission}}\n==A==\n                                                                                                             \nB' );
+	} );
+} );


### PR DESCRIPTION
Fix #245

This new code is vulnerable to deleting the wrong heading if someone puts a category in the wrong place (not at the bottom of the article), but I think that's an acceptable tradeoff for now. If it actually affects someone we can make the solution more complex in a future patch.