### PR TITLE
gitignore pywikibot files and folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ build
 */#*.*#
 *.swp
 certificates/
+pywikibot-*
+throttle.ctrl
+user-*
+venv/
+logs/
+apicache-py3/


### PR DESCRIPTION
When deploying, you need to install pywikibot. Need to gitignore these to not clutter up the repo.