### PR TITLE
update package.json to reflect repo name change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "afch-rewrite",
+  "name": "afc-helper",
   "version": "0.9.1",
   "description": "A tool for reviewing Articles for Creation submissions on the English Wikipedia.",
-  "homepage": "https://github.com/WPAFC/afch-rewrite",
+  "homepage": "https://github.com/wikimedia-gadgets/afc-helper",
   "bugs": {
-    "url": "https://github.com/WPAFC/afch-rewrite/issues"
+    "url": "https://github.com/wikimedia-gadgets/afc-helper/issues"
   },
   "license": "GPL-3.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/WPAFC/afch-rewrite/npm.git"
+    "url": "https://github.com/wikimedia-gadgets/afc-helper.git"
   },
   "scripts": {
     "test": "grunt test",


### PR DESCRIPTION
I'm not sure why repository: url: https://github.com/WPAFC/afch-rewrite/npm.git ended in npm.git. I have changed it to afc-helper.git. If that npm.git is necessary after all, please make a comment.