### PR TITLE
when accepting a draft, change user talk edit summary to wikilink to the draft, not to [[WP:AFC]]

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -2338,7 +2338,7 @@
 						AFCH.actions.notifyUser( submitter, {
 							message: AFCH.msg.get( 'accepted-submission',
 								{ $1: newPage, $2: data.newAssessment } ),
-							summary: 'Notification: Your [[Wikipedia:Articles for creation|Articles for creation]] submission has been accepted'
+							summary: "Notification: Your [[Insert accepted article's title here|Articles for creation]] submission has been accepted"
 						} );
 					} );
 				}

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -2338,7 +2338,7 @@
 						AFCH.actions.notifyUser( submitter, {
 							message: AFCH.msg.get( 'accepted-submission',
 								{ $1: newPage, $2: data.newAssessment } ),
-							summary: "Notification: Your [[Insert accepted article's title here|Articles for creation]] submission has been accepted"
+							summary: 'Notification: Your [[' + AFCH.consts.pagename + '|Articles for Creation submission]] has been accepted'
 						} );
 					} );
 				}


### PR DESCRIPTION
fix:- #305 
