### PR TITLE
Follow redirects when notifying users

### DIFF
--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -614,6 +614,7 @@
 			 *                          mode: {string} 'appendtext' or 'prependtext'; default: (replace everything)
 			 *                          hide: {bool} Set to true to supress logging in statusWindow
 			 *                          statusText: {string} message to show in status; default: "Editing"
+			 *                          followRedirects: {boolean} true to follow redirects, false to ignore redirects
 			 * @return {jQuery.Deferred} Resolves if saved with all data
 			 */
 			editPage: function ( pagename, options ) {
@@ -621,6 +622,11 @@
 
 				if ( !options ) {
 					options = {};
+				}
+
+				// Default to false
+				if ( !options.followRedirects ) {
+					options.followRedirects = false;
 				}
 
 				if ( !options.hide ) {
@@ -634,7 +640,8 @@
 					action: 'edit',
 					text: options.contents,
 					title: pagename,
-					summary: options.summary + AFCH.consts.summaryAd
+					summary: options.summary + AFCH.consts.summaryAd,
+					redirect: options.followRedirects
 				};
 
 				if ( pagename.indexOf( 'Draft:' ) === 0 ) {
@@ -777,7 +784,8 @@
 						summary: options.summary || 'Notifying user',
 						mode: 'appendtext',
 						statusText: 'Notifying',
-						hide: options.hide
+						hide: options.hide,
+						followRedirects: true
 					} )
 						.done( function () {
 							deferred.resolve();


### PR DESCRIPTION
Fixes #90

Advantages
- Simpler than patch #291
- The original intent of the function notifyUser was to follow redirects, indicated by the comment "Follows redirects and appends a message to the bottom of the user's talk page." from 2014. So this fixes that bug.

Disadvantages
- Will only follow 1 redirect, not 2+ redirects.
- The "Saved [[User talk:OldUsername]] (diff)" message shown to the AFC reviewer will be slightly incorrect. The diff will be correct, but OldUsername should ideally be NewUsername.