### PR TITLE
make warning links prettier

### DIFF
--- a/src/less/submissions.less
+++ b/src/less/submissions.less
@@ -131,7 +131,7 @@
 		padding: 8px 0px;
 
 		> a {
-			padding-left: 2px;
+			padding-left: 5px;
 			font-size: 0.8em;
 			color: @sexyblack;
 		}

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -942,7 +942,7 @@
 			if ( actionMessage !== false ) {
 				$action = $( '<a>' )
 					.addClass( 'link' )
-					.text( actionMessage || 'Edit page' )
+					.text( '(' + ( actionMessage || 'Edit page' ) + ')' )
 					.appendTo( $warning );
 
 				if ( typeof onAction === 'function' ) {


### PR DESCRIPTION
- add parentheses around them
- scoot the link a bit farther away from the warning message

Before:
<img width="441" alt="image" src="https://github.com/wikimedia-gadgets/afc-helper/assets/79697282/800948fc-f3f6-4e6e-9350-9adff0650fb6">

After:
<img width="454" alt="image" src="https://github.com/wikimedia-gadgets/afc-helper/assets/79697282/f8beb026-773f-42c9-9c43-067e3b3ba245">