### PR TITLE
hide submit button if no comment typed in

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -2102,9 +2102,22 @@
 
 	function showCommentOptions() {
 		loadView( 'comment', {} );
+
+		var $submitButton = $( '#afchSubmitForm' );
+		$submitButton.hide();
+
 		$( '#commentText' ).on( 'keyup', mw.util.debounce( 500, function () {
 			previewComment( $( '#commentText' ), $( '#commentPreview' ) );
+
+			// Hide the submit button if there is no comment typed in
+			var comment = $( '#commentText' ).val();
+			if ( comment.length > 0 ) {
+				$submitButton.show();
+			} else {
+				$submitButton.hide();
+			}
 		} ) );
+
 		addFormSubmitHandler( handleComment );
 	}
 


### PR DESCRIPTION
fix #105

This is the same approach used by the "decline" form, which hides the submit button until decline reasons are chosen.

<img width="1039" alt="2024-04-10_015913" src="https://github.com/wikimedia-gadgets/afc-helper/assets/79697282/b284c6c1-2e20-46b1-8244-7d19a0aaacc3">
<img width="1029" alt="2024-04-10_015931" src="https://github.com/wikimedia-gadgets/afc-helper/assets/79697282/3dd29306-5246-43b3-86c2-86d26c503979">
