### PR TITLE
refactor adding talk page banners

### DIFF
--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -1633,13 +1633,13 @@
 		 * @param {string} newAssessment Value of "Article assessment" dropdown list, or "" if blank
 		 * @param {number} revId Revision ID of the draft that is being accepted
 		 * @param {boolean} isBiography Value of the "Is the article a biography?" check box
-		 * @param {Array} newWikiProjects Value of the "Add WikiPrjects" chips
+		 * @param {Array} newWikiProjects Value of the "Add WikiPrjects" part of the form. The <input> is a chips interface called jquery.chosen. Note that if there are existing WikiProject banners on the page, the form will auto-add those to the "Add WikiProjects" part of the form when it first loads.
 		 * @param {string} lifeStatus Value of "Is the subject alive?" dropdown list ("unknown", "living", "dead")
 		 * @param {string} subjectName Value of the "Subject name (last, first)" text input, or "" if blank
-		 * @param {Array} existingWikiProjects
+		 * @param {Array<Object>} existingWikiProjects An array of associative arrays. The associative arrays contain the keys {string} displayName (example: Somalia), {string} templateName (example: WikiProject Somalia), and {boolean} alreadyOnPage
 		 * @param {boolean} alreadyHasWPBio
 		 * @param {null} existingWPBioTemplateName
-		 * @returns {Object} { talkText, countOfWikiProjectsAdded, countOfWikiProjectsRemoved }
+		 * @returns {Object} { {string} talkText, {number} countOfWikiProjectsAdded, {number} countOfWikiProjectsRemoved }
 		 */
 		addTalkPageBanners: function ( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName ) {
 			var talkTextPrefix = '';

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -1639,12 +1639,9 @@
 		 * @param {Array} existingWikiProjects
 		 * @param {boolean} alreadyHasWPBio
 		 * @param {null} existingWPBioTemplateName
-		 * @param {Function} removeFromArray AFCH.removeFromArray()
-		 * @param {Function} inArray $.inArray()
-		 * @param {Function} each $.each()
 		 * @returns {Object} { talkText, countOfWikiProjectsAdded, countOfWikiProjectsRemoved }
 		 */
-		addTalkPageBanners: function ( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName, removeFromArray, inArray, each ) {
+		addTalkPageBanners: function ( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName ) {
 			var talkTextPrefix = '';
 
 			// Add the AFC banner
@@ -1654,7 +1651,7 @@
 			// Add biography banner if specified
 			if ( isBiography ) {
 				// Ensure we don't have duplicate biography tags
-				removeFromArray( newWikiProjects, 'WikiProject Biography' );
+				AFCH.removeFromArray( newWikiProjects, 'WikiProject Biography' );
 
 				talkTextPrefix += ( '\n{{WikiProject Biography|living=' +
 					( lifeStatus !== 'unknown' ? ( lifeStatus === 'living' ? 'yes' : 'no' ) : '' ) +
@@ -1663,7 +1660,7 @@
 
 			// Add disambiguation banner if needed
 			if ( newAssessment === 'disambig' &&
-				inArray( 'WikiProject Disambiguation', newWikiProjects ) === -1 ) {
+				$.inArray( 'WikiProject Disambiguation', newWikiProjects ) === -1 ) {
 				newWikiProjects.push( 'WikiProject Disambiguation' );
 			}
 
@@ -1686,10 +1683,10 @@
 				wikiProjectsToRemove.push( existingWPBioTemplateName || 'wikiproject biography' );
 			}
 
-			each( wikiProjectsToAdd, function ( _index, templateName ) {
+			$.each( wikiProjectsToAdd, function ( _index, templateName ) {
 				talkTextPrefix += '\n{{' + templateName + '|class=' + newAssessment + '}}';
 			} );
-			each( wikiProjectsToRemove, function ( _index, templateName ) {
+			$.each( wikiProjectsToRemove, function ( _index, templateName ) {
 				// Regex from https://stackoverflow.com/a/5306111/1757964
 				var sanitizedTemplateName = templateName.replace( /[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&' );
 				talkText = talkText.replace( new RegExp( '\\n?\\{\\{\\s*' + sanitizedTemplateName + '\\s*.+?\\}\\}', 'is' ), '' );

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -2275,65 +2275,31 @@
 				// ---------
 
 				talkPage.getText().done( function ( talkText ) {
-					var talkTextPrefix = '';
-
-					// Add the AFC banner
-					talkTextPrefix += '{{subst:WPAFC/article|class=' + data.newAssessment +
-						( afchPage.additionalData.revId ? '|oldid=' + afchPage.additionalData.revId : '' ) + '}}';
-
-					// Add biography banner if specified
-					if ( data.isBiography ) {
-						// Ensure we don't have duplicate biography tags
-						AFCH.removeFromArray( data.newWikiProjects, 'WikiProject Biography' );
-
-						talkTextPrefix += ( '\n{{WikiProject Biography|living=' +
-							( data.lifeStatus !== 'unknown' ? ( data.lifeStatus === 'living' ? 'yes' : 'no' ) : '' ) +
-							'|class=' + data.newAssessment + '|listas=' + data.subjectName + '}}' );
-					}
-
-					if ( data.newAssessment === 'disambig' &&
-						$.inArray( 'WikiProject Disambiguation', data.newWikiProjects ) === -1 ) {
-						data.newWikiProjects.push( 'WikiProject Disambiguation' );
-					}
-
-					// Add and remove WikiProjects
-					var wikiProjectsToAdd = data.newWikiProjects.filter( function ( newTemplateName ) {
-						return !data.existingWikiProjects.some( function ( existingTplObj ) {
-							return existingTplObj.templateName === newTemplateName;
-						} );
-					} );
-					var wikiProjectsToRemove = data.existingWikiProjects.filter( function ( existingTplObj ) {
-						return !data.newWikiProjects.some( function ( newTemplateName ) {
-							return existingTplObj.templateName === newTemplateName;
-						} );
-					} ).map( function ( templateObj ) {
-						return templateObj.realTemplateName || templateObj.templateName;
-					} );
-					if ( data.alreadyHasWPBio && !data.isBiography ) {
-						wikiProjectsToRemove.push( data.existingWPBioTemplateName || 'wikiproject biography' );
-					}
-
-					$.each( wikiProjectsToAdd, function ( _index, templateName ) {
-						talkTextPrefix += '\n{{' + templateName + '|class=' + data.newAssessment + '}}';
-					} );
-					$.each( wikiProjectsToRemove, function ( _index, templateName ) {
-						// Regex from https://stackoverflow.com/a/5306111/1757964
-						var sanitizedTemplateName = templateName.replace( /[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&' );
-						talkText = talkText.replace( new RegExp( '\\n?\\{\\{\\s*' + sanitizedTemplateName + '\\s*.+?\\}\\}', 'is' ), '' );
-					} );
-
-					// We prepend the text so that talk page content is not removed
-					// (e.g. pages in `Draft:` namespace with discussion)
-					talkText = talkTextPrefix + '\n\n' + talkText;
+					var results = AFCH.addTalkPageBanners(
+						talkText,
+						data.newAssessment,
+						afchPage.additionalData.revId,
+						data.isBiography,
+						data.newWikiProjects,
+						data.lifeStatus,
+						data.subjectName,
+						data.existingWikiProjects,
+						data.alreadyHasWPBio,
+						data.existingWPBioTemplateName,
+						AFCH.removeFromArray,
+						$.inArray,
+						$.each
+					);
+					talkText = results.talkText;
 
 					var summary = 'Placing [[Wikipedia:Articles for creation|Articles for creation]] banner';
-					if ( wikiProjectsToAdd.length > 0 ) {
-						summary += ', adding ' + wikiProjectsToAdd.length +
-							' WikiProject banner' + ( ( wikiProjectsToAdd.length === 1 ) ? '' : 's' );
+					if ( results.countOfWikiProjectsAdded > 0 ) {
+						summary += ', adding ' + results.countOfWikiProjectsAdded +
+							' WikiProject banner' + ( ( results.countOfWikiProjectsAdded === 1 ) ? '' : 's' );
 					}
-					if ( wikiProjectsToRemove.length > 0 ) {
-						summary += ', removing ' + wikiProjectsToRemove.length +
-							' WikiProject banner' + ( ( wikiProjectsToRemove.length === 1 ) ? '' : 's' );
+					if ( results.countOfWikiProjectsRemoved > 0 ) {
+						summary += ', removing ' + results.countOfWikiProjectsRemoved +
+							' WikiProject banner' + ( ( results.countOfWikiProjectsRemoved === 1 ) ? '' : 's' );
 					}
 
 					if ( comments && comments.length > 0 ) {

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -2285,10 +2285,7 @@
 						data.subjectName,
 						data.existingWikiProjects,
 						data.alreadyHasWPBio,
-						data.existingWPBioTemplateName,
-						AFCH.removeFromArray,
-						$.inArray,
-						$.each
+						data.existingWPBioTemplateName
 					);
 					talkText = results.talkText;
 

--- a/tests/test-core.js
+++ b/tests/test-core.js
@@ -119,7 +119,7 @@ describe( 'AFCH.removeEmptySectionAtEnd', function () {
 } );
 
 describe( 'AFCH.addTalkPageBanners', function () {
-	it( 'accept form is all default values, talk page is blank', function () {
+	it( 'talk page is blank', function () {
 		var talkText = '';
 		var newAssessment = '';
 		var revId = 592485;
@@ -130,13 +130,13 @@ describe( 'AFCH.addTalkPageBanners', function () {
 		var existingWikiProjects = [];
 		var alreadyHasWPBio = false;
 		var existingWPBioTemplateName = null;
-		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName, AFCH.removeFromArray, $.inArray, $.each );
+		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
 		expect( output.talkText ).toBe( '{{subst:WPAFC/article|class=|oldid=592485}}\n\n' );
 		expect( output.countOfWikiProjectsAdded ).toBe( 0 );
 		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
 	} );
 
-	it( 'accept form is all default values, talk page has existing sections', function () {
+	it( 'talk page has existing sections', function () {
 		var talkText = '== Hello ==\nI have a question. Can you help answer it? –[[User:Novem Linguae|<span style="color:blue">\'\'\'Novem Linguae\'\'\'</span>]] <small>([[User talk:Novem Linguae|talk]])</small> 20:22, 10 April 2024 (UTC)';
 		var newAssessment = '';
 		var revId = 592485;
@@ -147,32 +147,82 @@ describe( 'AFCH.addTalkPageBanners', function () {
 		var existingWikiProjects = [];
 		var alreadyHasWPBio = false;
 		var existingWPBioTemplateName = null;
-		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName, AFCH.removeFromArray, $.inArray, $.each );
+		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
 		expect( output.talkText ).toBe( '{{subst:WPAFC/article|class=|oldid=592485}}\n\n== Hello ==\nI have a question. Can you help answer it? –[[User:Novem Linguae|<span style="color:blue">\'\'\'Novem Linguae\'\'\'</span>]] <small>([[User talk:Novem Linguae|talk]])</small> 20:22, 10 April 2024 (UTC)' );
 		expect( output.countOfWikiProjectsAdded ).toBe( 0 );
 		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
 	} );
 
-	// TODO: unexpected \n between new banners and old banners
-	it( 'accept form is all default values, talk page has existing WikiProject banners', function () {
+	// FIXME: unexpected \n between new banners and old banners. https://github.com/wikimedia-gadgets/afc-helper/issues/330
+	it( 'talk page has existing WikiProject banners', function () {
 		var talkText = '{{WikiProject Women}}\n{{WikiProject Women\'s sport}}\n{{WikiProject Somalia}}';
 		var newAssessment = '';
-		var revId = 592485;
+		var revId = 592507;
 		var isBiography = false;
-		var newWikiProjects = [];
+		var newWikiProjects = [ 'WikiProject Somalia', 'WikiProject Women', 'WikiProject Women\'s sport' ];
 		var lifeStatus = 'unknown';
 		var subjectName = '';
-		var existingWikiProjects = [];
+		var existingWikiProjects = [
+			{
+				displayName: 'Somalia',
+				templateName: 'WikiProject Somalia',
+				alreadyOnPage: true
+			},
+			{
+				displayName: 'Women',
+				templateName: 'WikiProject Women',
+				alreadyOnPage: true
+			},
+			{
+				displayName: 'Women\'s sport',
+				templateName: 'WikiProject Women\'s sport',
+				alreadyOnPage: true
+			}
+		];
 		var alreadyHasWPBio = false;
 		var existingWPBioTemplateName = null;
-		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName, AFCH.removeFromArray, $.inArray, $.each );
-		expect( output.talkText ).toBe( '{{subst:WPAFC/article|class=|oldid=592485}}\n\n{{WikiProject Women}}\n{{WikiProject Women\'s sport}}\n{{WikiProject Somalia}}' );
+		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
+		expect( output.talkText ).toBe( '{{subst:WPAFC/article|class=|oldid=592507}}\n\n{{WikiProject Women}}\n{{WikiProject Women\'s sport}}\n{{WikiProject Somalia}}' );
 		expect( output.countOfWikiProjectsAdded ).toBe( 0 );
 		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
 	} );
 
-	// TODO: need a test that has non-default input for existingWikiProjects, alreadyHasWPBio, and existingWPBioTemplateName
-	it( 'accept form is a biography with all fields filled in, talk page is blank', function () {
+	// FIXME: the edit summary of 1 WikiProject banner removed is correct, but this doesn't actually remove the WikiProject banner from the talk page. https://github.com/wikimedia-gadgets/afc-helper/issues/329
+	it( 'remove an existing WikiProject', function () {
+		var talkText = '{{WikiProject Women}}\n{{WikiProject Women\'s sport}}\n{{WikiProject Somalia}}';
+		var newAssessment = '';
+		var revId = 592507;
+		var isBiography = false;
+		// user de-selected WikiProject Somalia
+		var newWikiProjects = [ 'WikiProject Women', 'WikiProject Women\'s sport' ];
+		var lifeStatus = 'unknown';
+		var subjectName = '';
+		var existingWikiProjects = [
+			{
+				displayName: 'Somalia',
+				templateName: 'WikiProject Somalia',
+				alreadyOnPage: true
+			},
+			{
+				displayName: 'Women',
+				templateName: 'WikiProject Women',
+				alreadyOnPage: true
+			},
+			{
+				displayName: 'Women\'s sport',
+				templateName: 'WikiProject Women\'s sport',
+				alreadyOnPage: true
+			}
+		];
+		var alreadyHasWPBio = false;
+		var existingWPBioTemplateName = null;
+		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
+		expect( output.talkText ).toBe( '{{subst:WPAFC/article|class=|oldid=592507}}\n\n{{WikiProject Women}}\n{{WikiProject Women\'s sport}}\n{{WikiProject Somalia}}' );
+		expect( output.countOfWikiProjectsAdded ).toBe( 0 );
+		expect( output.countOfWikiProjectsRemoved ).toBe( 1 );
+	} );
+
+	it( 'accept form is a biography with all fields filled in', function () {
 		var talkText = '';
 		var newAssessment = 'B';
 		var revId = 592496;
@@ -183,9 +233,56 @@ describe( 'AFCH.addTalkPageBanners', function () {
 		var existingWikiProjects = [];
 		var alreadyHasWPBio = false;
 		var existingWPBioTemplateName = null;
-		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName, AFCH.removeFromArray, $.inArray, $.each );
+		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
 		expect( output.talkText ).toBe( '{{subst:WPAFC/article|class=B|oldid=592496}}\n{{WikiProject Biography|living=yes|class=B|listas=Jones, Bob}}\n{{WikiProject Africa|class=B}}\n{{WikiProject Alabama|class=B}}\n\n' );
 		expect( output.countOfWikiProjectsAdded ).toBe( 2 );
+		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
+	} );
+
+	// FIXME: is supposed to remove the {{wikiproject biography}} template and report 1 template removed, but does not. code outside of AFCH.addTalkPageBanners() is incorrectly calculating alreadyHasWPBio as false
+	// FIXME: 2 extra line breaks in the output
+	it( 'talk page has {{wikiproject biography}}, and user selects that it\'s not a biography, so should remove {{wikiproject biography}}', function () {
+		var talkText = '{{wikiproject biography|living=yes|class=B|listas=Jones, Bob}}\n{{WikiProject Somalia}}';
+		var newAssessment = '';
+		var revId = 592496;
+		var isBiography = false;
+		var newWikiProjects = [ 'WikiProject Biography', 'WikiProject Somalia' ];
+		var lifeStatus = 'unknown';
+		var subjectName = '';
+		var existingWikiProjects = [
+			{
+				displayName: 'Biography',
+				templateName: 'WikiProject Biography',
+				alreadyOnPage: true
+			},
+			{
+				displayName: 'Somalia',
+				templateName: 'WikiProject Somalia',
+				alreadyOnPage: true
+			}
+		];
+		var alreadyHasWPBio = false;
+		var existingWPBioTemplateName = null;
+		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
+		expect( output.talkText ).toBe( '{{subst:WPAFC/article|class=|oldid=592496}}\n\n{{wikiproject biography|living=yes|class=B|listas=Jones, Bob}}\n{{WikiProject Somalia}}' );
+		expect( output.countOfWikiProjectsAdded ).toBe( 0 );
+		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
+	} );
+
+	it( 'user selects class = disambiguation', function () {
+		var talkText = '';
+		var newAssessment = 'disambig';
+		var revId = 592681;
+		var isBiography = false;
+		var newWikiProjects = [];
+		var lifeStatus = 'unknown';
+		var subjectName = '';
+		var existingWikiProjects = [];
+		var alreadyHasWPBio = false;
+		var existingWPBioTemplateName = null;
+		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
+		expect( output.talkText ).toBe( '{{subst:WPAFC/article|class=disambig|oldid=592681}}\n{{WikiProject Disambiguation|class=disambig}}\n\n' );
+		expect( output.countOfWikiProjectsAdded ).toBe( 1 );
 		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
 	} );
 } );

--- a/tests/test-core.js
+++ b/tests/test-core.js
@@ -117,3 +117,75 @@ describe( 'AFCH.removeEmptySectionAtEnd', function () {
 		expect( output ).toBe( '{{AFC submission}}\n==A==\n                                                                                                             \nB' );
 	} );
 } );
+
+describe( 'AFCH.addTalkPageBanners', function () {
+	it( 'accept form is all default values, talk page is blank', function () {
+		var talkText = '';
+		var newAssessment = '';
+		var revId = 592485;
+		var isBiography = false;
+		var newWikiProjects = [];
+		var lifeStatus = 'unknown';
+		var subjectName = '';
+		var existingWikiProjects = [];
+		var alreadyHasWPBio = false;
+		var existingWPBioTemplateName = null;
+		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName, AFCH.removeFromArray, $.inArray, $.each );
+		expect( output.talkText ).toBe( '{{subst:WPAFC/article|class=|oldid=592485}}\n\n' );
+		expect( output.countOfWikiProjectsAdded ).toBe( 0 );
+		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
+	} );
+
+	it( 'accept form is all default values, talk page has existing sections', function () {
+		var talkText = '== Hello ==\nI have a question. Can you help answer it? –[[User:Novem Linguae|<span style="color:blue">\'\'\'Novem Linguae\'\'\'</span>]] <small>([[User talk:Novem Linguae|talk]])</small> 20:22, 10 April 2024 (UTC)';
+		var newAssessment = '';
+		var revId = 592485;
+		var isBiography = false;
+		var newWikiProjects = [];
+		var lifeStatus = 'unknown';
+		var subjectName = '';
+		var existingWikiProjects = [];
+		var alreadyHasWPBio = false;
+		var existingWPBioTemplateName = null;
+		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName, AFCH.removeFromArray, $.inArray, $.each );
+		expect( output.talkText ).toBe( '{{subst:WPAFC/article|class=|oldid=592485}}\n\n== Hello ==\nI have a question. Can you help answer it? –[[User:Novem Linguae|<span style="color:blue">\'\'\'Novem Linguae\'\'\'</span>]] <small>([[User talk:Novem Linguae|talk]])</small> 20:22, 10 April 2024 (UTC)' );
+		expect( output.countOfWikiProjectsAdded ).toBe( 0 );
+		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
+	} );
+
+	// TODO: unexpected \n between new banners and old banners
+	it( 'accept form is all default values, talk page has existing WikiProject banners', function () {
+		var talkText = '{{WikiProject Women}}\n{{WikiProject Women\'s sport}}\n{{WikiProject Somalia}}';
+		var newAssessment = '';
+		var revId = 592485;
+		var isBiography = false;
+		var newWikiProjects = [];
+		var lifeStatus = 'unknown';
+		var subjectName = '';
+		var existingWikiProjects = [];
+		var alreadyHasWPBio = false;
+		var existingWPBioTemplateName = null;
+		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName, AFCH.removeFromArray, $.inArray, $.each );
+		expect( output.talkText ).toBe( '{{subst:WPAFC/article|class=|oldid=592485}}\n\n{{WikiProject Women}}\n{{WikiProject Women\'s sport}}\n{{WikiProject Somalia}}' );
+		expect( output.countOfWikiProjectsAdded ).toBe( 0 );
+		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
+	} );
+
+	// TODO: need a test that has non-default input for existingWikiProjects, alreadyHasWPBio, and existingWPBioTemplateName
+	it( 'accept form is a biography with all fields filled in, talk page is blank', function () {
+		var talkText = '';
+		var newAssessment = 'B';
+		var revId = 592496;
+		var isBiography = true;
+		var newWikiProjects = [ 'WikiProject Africa', 'WikiProject Alabama' ];
+		var lifeStatus = 'living';
+		var subjectName = 'Jones, Bob';
+		var existingWikiProjects = [];
+		var alreadyHasWPBio = false;
+		var existingWPBioTemplateName = null;
+		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName, AFCH.removeFromArray, $.inArray, $.each );
+		expect( output.talkText ).toBe( '{{subst:WPAFC/article|class=B|oldid=592496}}\n{{WikiProject Biography|living=yes|class=B|listas=Jones, Bob}}\n{{WikiProject Africa|class=B}}\n{{WikiProject Alabama|class=B}}\n\n' );
+		expect( output.countOfWikiProjectsAdded ).toBe( 2 );
+		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
+	} );
+} );


### PR DESCRIPTION
- Extract all code related to adding WikiProject banners to the draft talk pages to its own function. Goal is to get this "wikicode in -> wikicode out" style code to be unit testable, in preparation for [future work](https://github.com/wikimedia-gadgets/afc-helper/issues?q=is%3Aissue+label%3Adraft-talk-page-wikitext+).
- Add some unit tests.

Should be a no-op.