### PR TITLE
add edit conflict detection

### DIFF
--- a/src/less/submissions.less
+++ b/src/less/submissions.less
@@ -70,6 +70,11 @@
 		vertical-align: top;
 	}
 
+	#afchEditConflict {
+		display: none;
+		color: red;
+	}
+
 	#afchSubmitForm {
 		text-align: center;
 		width: 30%;

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -93,7 +93,6 @@
 			if ( window.afchSuppressDevEdits === false ) {
 				AFCH.consts.mockItUp = false;
 			}
-			AFCH.consts.mockItUp = true;
 
 			// Check whitelist if necessary, but don't delay loading of the
 			// script for users who ARE allowed; rather, just destroy the

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -93,6 +93,7 @@
 			if ( window.afchSuppressDevEdits === false ) {
 				AFCH.consts.mockItUp = false;
 			}
+			AFCH.consts.mockItUp = true;
 
 			// Check whitelist if necessary, but don't delay loading of the
 			// script for users who ARE allowed; rather, just destroy the

--- a/src/templates/tpl-submissions.html
+++ b/src/templates/tpl-submissions.html
@@ -169,6 +169,8 @@
 			<input type="checkbox" id="notifyUser" class="afch-input" checked/>
 		</div>
 
+		<div id="afchEditConflict"></div>
+
 		<div id="afchSubmitForm" data-running="Accepting submission..." class="gradient-button accept">Accept &amp; publish</div>
 
 	</div>
@@ -304,6 +306,8 @@
 			</div>
 		</div>
 
+		<div id="afchEditConflict"></div>
+
 		<div id="afchSubmitForm" data-running="Declining submission..." class="gradient-button button-centered decline hidden">Decline submission</div>
 
 	</div>
@@ -321,10 +325,12 @@
 
 		<div id="commentPreview"></div>
 
-	<div class="afch-option">
-		<input type="checkbox" id="notifyUser" class="afch-input" {{#notifyByDefault}}checked{{/notifyByDefault}} />
-		<label for="notifyUser" class="afch-label">Notify submitter</label>
-	</div>
+		<div class="afch-option">
+			<input type="checkbox" id="notifyUser" class="afch-input" {{#notifyByDefault}}checked{{/notifyByDefault}} />
+			<label for="notifyUser" class="afch-label">Notify submitter</label>
+		</div>
+
+		<div id="afchEditConflict"></div>
 
 		<div id="afchSubmitForm" data-running="Commenting on submission..." class="gradient-button button-centered comment">Post comment</div>
 
@@ -351,6 +357,8 @@
 			<div id="submitterNameStatus" class="error"></div>
 		</div>
 
+		<div id="afchEditConflict"></div>
+
 		<div id="afchSubmitForm" data-running="Submitting..." class="gradient-button button-centered submit">Submit</div>
 
 	</div>
@@ -365,10 +373,11 @@
 			placeholder="Enter your rationale for postponing deletion, which will be added to the submission as a new comment."
 			cols="100" rows="5"></textarea>
 
+		<div id="afchEditConflict"></div>
+
 		<div id="afchSubmitForm" data-running="Postponing..." class="gradient-button button-centered postpone-g13">
 			Postpone deletion
 		</div>
-
 	</div>
 </div>
 <!-- /postpone-g13 -->


### PR DESCRIPTION
<img width="1032" alt="image" src="https://github.com/wikimedia-gadgets/afc-helper/assets/79697282/6bb97a02-79f9-47e9-9a45-cbcbdae02d0a">

- Only checks when the submit button is clicked, to avoid spamming the Wikimedia API.
- When an edit conflict is detected, hides the submit button and displays a red warning message with a link to the draft's edit history.
- Does not allow a user to continue if an edit conflict is detected, forcing the user to reload the page. This is because continuing anyway would overwrite the previous edit.
- Doesn't currently save any form data on refresh, which would require more code and potentially be complicated to store and reload the entire state of a complex form like the decline form. Hopefully the user is smart enough to Ctrl-C if they typed a bunch of stuff into the comment box.

Fixes #153