### PR TITLE
change "reloaded automatically" to "reload"

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1331,7 +1331,7 @@
 
 			// Also, automagically reload the page in place
 			$( '#mw-content-text' ).load( AFCH.consts.pagelink + ' #mw-content-text', function () {
-				$afch.find( '#reloadLink' ).text( '(reloaded automatically)' );
+				$afch.find( '#reloadLink' ).text( '(reload)' );
 				// Fire the hook for new page content
 				mw.hook( 'wikipage.content' ).fire( $( '#mw-content-text' ) );
 			} );


### PR DESCRIPTION
change "reloaded automatically" to "reload"

It doesn't auto refresh the page for you. You have to click the link. So "reloaded automatically" is factually incorrect.

<img width="1035" alt="image" src="https://github.com/wikimedia-gadgets/afc-helper/assets/79697282/9e437ca5-1d3c-41fb-aa95-9b9a675e65db">
