### PR TITLE
don't place {{Talk header}} on user talk pages

### DIFF
--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -808,7 +808,7 @@
 
 				userTalkPage.exists().done( function ( exists ) {
 					userTalkPage.edit( {
-						contents: ( exists ? '' : '{{Talk header}}' ) + '\n\n' + options.message,
+						contents: options.message,
 						summary: options.summary || 'Notifying user',
 						mode: 'appendtext',
 						statusText: 'Notifying',


### PR DESCRIPTION
Current behavior is to auto place {{Talk header}} at the top of uncreated user talk pages.

This is causing a double signature bug when using the discussiontoolsapi. Removing the {{Talk header}} placement code would be a very clean fix for this.

Fixes #347