### PR TITLE
don't detect own edits as edit conflict

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -2695,13 +2695,13 @@
 			titles: [ mw.config.get( 'wgPageName' ) ],
 			formatversion: 2,
 			rvstartid: mw.config.get( 'wgRevisionId' ),
-			rvdir: 'newer'
+			rvdir: 'newer',
+			rvexcludeuser: mw.config.get( 'wgUserName' )
 		};
 		var promise = AFCH.api.postWithEditToken( request )
 			.then( function ( data ) {
 				var revisions = data.query.pages[ 0 ].revisions;
-				// 1 revision = no edit conflict, 2+ revisions = edit conflict.
-				if ( revisions && revisions.length > 1 ) {
+				if ( revisions && revisions.length > 0 ) {
 					return true;
 				}
 				return false;


### PR DESCRIPTION
Fixes a bug reported by DoubleGrazing at https://en.wikipedia.org/wiki/Wikipedia_talk:WikiProject_Articles_for_creation#Commenting_causes_'edit_conflict'