### PR TITLE
Revert "don't detect own edits as edit conflict"

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -2695,13 +2695,13 @@
 			titles: [ mw.config.get( 'wgPageName' ) ],
 			formatversion: 2,
 			rvstartid: mw.config.get( 'wgRevisionId' ),
-			rvdir: 'newer',
-			rvexcludeuser: mw.config.get( 'wgUserName' )
+			rvdir: 'newer'
 		};
 		var promise = AFCH.api.postWithEditToken( request )
 			.then( function ( data ) {
 				var revisions = data.query.pages[ 0 ].revisions;
-				if ( revisions && revisions.length > 0 ) {
+				// 1 revision = no edit conflict, 2+ revisions = edit conflict.
+				if ( revisions && revisions.length > 1 ) {
 					return true;
 				}
 				return false;


### PR DESCRIPTION
Reverts wikimedia-gadgets/afc-helper#352

Has a bug where edits that shouldn't be are being detected as edit conflicts. Maybe even all edits.

Steps to reproduce:
* go to a draft that isn't submitted
* try to submit