### PR TITLE
Use WikiProject banner shell on draft talk pages

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,16 @@
 		"mw": "writable",
 		"OO": "readonly"
 	},
+	"overrides": [
+		{
+			"files": [
+				"tests/*"
+			],
+			"parserOptions": {
+				"ecmaVersion": 6
+			}
+		}
+	],
 	"rules": {
 		"camelcase": "off",
 		"eqeqeq": "warn",

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -1708,10 +1708,26 @@
 			// (e.g. pages in `Draft:` namespace with discussion)
 			talkText = talkTextPrefix + '\n\n' + talkText;
 
+			// Add banner shell if needed
+			var banners = talkText.match( /{{(?:wikiproject[^}]+}}|subst:wpafc)/gi );
+			// https://en.wikipedia.org/wiki/Special:WhatLinksHere?target=Template%3AWikiProject+banner+shell&namespace=&hidetrans=1&hidelinks=1
+			var bannerShellDetectionRegex = /{{(?:WikiProject banner shell|WikiProjectBanners|WikiProject Banners|WPB|WPBS|WikiProject cooperation shell|Wikiprojectbannershell|WikiProject Banner Shell|Wpb|WPBannerShell|Wpbs|Wikiprojectbanners|WP Banner Shell|WP banner shell|Bannershell|Wikiproject banner shell|WIkiProjectBanner Shell|WikiProjectBannerShell|WikiProject BannerShell|Coopshell|WikiprojectBannerShell|WikiProject Shell|Scope shell|Project shell|WikiProject shell|WikiProject banner|Wpbannershell|Multiple wikiprojects|Wikiproject banner holder|Project banner holder|WikiProject banner shell\/test1|Article assessment|WikiProject bannershell)/i;
+			var hasBannerShell = talkText.match( bannerShellDetectionRegex );
+			if ( banners.length > 1 && !hasBannerShell ) {
+				var bannerShellStart = '{{WikiProject banner shell|';
+				var bannerShellEnd = '}}';
+				var firstBanner = banners[ 0 ];
+				var lastBanner = banners.slice( -1 )[ 0 ];
+				talkText = talkText.replace( firstBanner, bannerShellStart + '\n' + firstBanner );
+				talkText = talkText.replace( lastBanner, lastBanner + '\n' + bannerShellEnd );
+			}
+
 			return {
 				talkText: talkText,
 				countOfWikiProjectsAdded: wikiProjectsToAdd.length,
-				countOfWikiProjectsRemoved: wikiProjectsToRemove.length
+				countOfWikiProjectsRemoved: wikiProjectsToRemove.length,
+				// adding this param mainly for unit tests, so we can test how well the banner detection algorithm works
+				bannerCount: banners.length
 			};
 		},
 

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -1709,7 +1709,7 @@
 			talkText = talkTextPrefix + '\n\n' + talkText;
 
 			// Add banner shell if needed
-			var banners = talkText.match( /{{(?:wikiproject[^}]+}}|subst:wpafc)/gi );
+			var banners = talkText.match( /{{(?:wikiproject[^}]+}}|subst:wpafc|football)/gi );
 			// https://en.wikipedia.org/wiki/Special:WhatLinksHere?target=Template%3AWikiProject+banner+shell&namespace=&hidetrans=1&hidelinks=1
 			var bannerShellDetectionRegex = /{{(?:WikiProject banner shell|WikiProjectBanners|WikiProject Banners|WPB|WPBS|WikiProject cooperation shell|Wikiprojectbannershell|WikiProject Banner Shell|Wpb|WPBannerShell|Wpbs|Wikiprojectbanners|WP Banner Shell|WP banner shell|Bannershell|Wikiproject banner shell|WIkiProjectBanner Shell|WikiProjectBannerShell|WikiProject BannerShell|Coopshell|WikiprojectBannerShell|WikiProject Shell|Scope shell|Project shell|WikiProject shell|WikiProject banner|Wpbannershell|Multiple wikiprojects|Wikiproject banner holder|Project banner holder|WikiProject banner shell\/test1|Article assessment|WikiProject bannershell)/i;
 			var hasBannerShell = talkText.match( bannerShellDetectionRegex );
@@ -1722,11 +1722,22 @@
 				talkText = talkText.replace( lastBanner, lastBanner + '\n' + bannerShellEnd );
 			}
 
+			// If banner shell is present, comply with [[WP:PIQA]]. Add the class only to the banner shell. Delete any other class parameters.
+			hasBannerShell = talkText.match( bannerShellDetectionRegex );
+			if ( hasBannerShell ) {
+				// delete all |class= from the entire talk page
+				talkText = talkText.replace( /[\n|}]class\s*=\s*[^\n|}]*([\n|}])/g, '$1' );
+				// add |class= to the banner shell only
+				if ( newAssessment ) {
+					talkText = talkText.replace( bannerShellDetectionRegex, '$&|class=' + newAssessment );
+				}
+			}
+
 			return {
 				talkText: talkText,
 				countOfWikiProjectsAdded: wikiProjectsToAdd.length,
 				countOfWikiProjectsRemoved: wikiProjectsToRemove.length,
-				// adding this param mainly for unit tests, so we can test how well the banner detection algorithm works
+				// adding this param for unit tests, so we can test that the banner detection algorithm works
 				bannerCount: banners.length
 			};
 		},

--- a/tests/test-core.js
+++ b/tests/test-core.js
@@ -140,6 +140,7 @@ describe( 'AFCH.addTalkPageBanners', function () {
 		);
 		expect( output.countOfWikiProjectsAdded ).toBe( 0 );
 		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
+		expect( output.bannerCount ).toBe( 1 );
 	} );
 
 	it( 'talk page has existing sections', function () {
@@ -164,6 +165,7 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		);
 		expect( output.countOfWikiProjectsAdded ).toBe( 0 );
 		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
+		expect( output.bannerCount ).toBe( 1 );
 	} );
 
 	// FIXME: unexpected \n between new banners and old banners. https://github.com/wikimedia-gadgets/afc-helper/issues/330
@@ -199,14 +201,17 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		var existingWPBioTemplateName = null;
 		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
 		expect( output.talkText ).toBe(
-`{{subst:WPAFC/article|class=|oldid=592507}}
+`{{WikiProject banner shell|
+{{subst:WPAFC/article|class=|oldid=592507}}
 
 {{WikiProject Women}}
 {{WikiProject Women's sport}}
-{{WikiProject Somalia}}`
+{{WikiProject Somalia}}
+}}`
 		);
 		expect( output.countOfWikiProjectsAdded ).toBe( 0 );
 		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
+		expect( output.bannerCount ).toBe( 4 );
 	} );
 
 	// FIXME: the edit summary of 1 WikiProject banner removed is correct, but this doesn't actually remove the WikiProject banner from the talk page. https://github.com/wikimedia-gadgets/afc-helper/issues/329
@@ -243,14 +248,17 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		var existingWPBioTemplateName = null;
 		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
 		expect( output.talkText ).toBe(
-`{{subst:WPAFC/article|class=|oldid=592507}}
+`{{WikiProject banner shell|
+{{subst:WPAFC/article|class=|oldid=592507}}
 
 {{WikiProject Women}}
 {{WikiProject Women's sport}}
-{{WikiProject Somalia}}`
+{{WikiProject Somalia}}
+}}`
 		);
 		expect( output.countOfWikiProjectsAdded ).toBe( 0 );
 		expect( output.countOfWikiProjectsRemoved ).toBe( 1 );
+		expect( output.bannerCount ).toBe( 4 );
 	} );
 
 	it( 'accept form is a biography with all fields filled in', function () {
@@ -266,15 +274,18 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		var existingWPBioTemplateName = null;
 		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
 		expect( output.talkText ).toBe(
-`{{subst:WPAFC/article|class=B|oldid=592496}}
+`{{WikiProject banner shell|
+{{subst:WPAFC/article|class=B|oldid=592496}}
 {{WikiProject Biography|living=yes|class=B|listas=Jones, Bob}}
 {{WikiProject Africa|class=B}}
 {{WikiProject Alabama|class=B}}
+}}
 
 `
 		);
 		expect( output.countOfWikiProjectsAdded ).toBe( 2 );
 		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
+		expect( output.bannerCount ).toBe( 4 );
 	} );
 
 	it( 'lifeStatus = dead', function () {
@@ -290,13 +301,16 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		var existingWPBioTemplateName = null;
 		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
 		expect( output.talkText ).toBe(
-`{{subst:WPAFC/article|class=|oldid=592496}}
+`{{WikiProject banner shell|
+{{subst:WPAFC/article|class=|oldid=592496}}
 {{WikiProject Biography|living=no|class=|listas=}}
+}}
 
 `
 		);
 		expect( output.countOfWikiProjectsAdded ).toBe( 0 );
 		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
+		expect( output.bannerCount ).toBe( 2 );
 	} );
 
 	// FIXME: is supposed to remove the {{wikiproject biography}} template and report 1 template removed, but does not. code outside of AFCH.addTalkPageBanners() is incorrectly calculating alreadyHasWPBio as false
@@ -327,13 +341,16 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		var existingWPBioTemplateName = null;
 		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
 		expect( output.talkText ).toBe(
-`{{subst:WPAFC/article|class=|oldid=592496}}
+`{{WikiProject banner shell|
+{{subst:WPAFC/article|class=|oldid=592496}}
 
 {{wikiproject biography|living=yes|class=B|listas=Jones, Bob}}
-{{WikiProject Somalia}}`
+{{WikiProject Somalia}}
+}}`
 		);
 		expect( output.countOfWikiProjectsAdded ).toBe( 0 );
 		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
+		expect( output.bannerCount ).toBe( 3 );
 	} );
 
 	it( 'user selects class = disambiguation', function () {
@@ -349,12 +366,15 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		var existingWPBioTemplateName = null;
 		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
 		expect( output.talkText ).toBe(
-`{{subst:WPAFC/article|class=disambig|oldid=592681}}
+`{{WikiProject banner shell|
+{{subst:WPAFC/article|class=disambig|oldid=592681}}
 {{WikiProject Disambiguation|class=disambig}}
+}}
 
 `
 		);
 		expect( output.countOfWikiProjectsAdded ).toBe( 1 );
 		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
+		expect( output.bannerCount ).toBe( 2 );
 	} );
 } );

--- a/tests/test-core.js
+++ b/tests/test-core.js
@@ -202,7 +202,7 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
 		expect( output.talkText ).toBe(
 `{{WikiProject banner shell|
-{{subst:WPAFC/article|class=|oldid=592507}}
+{{subst:WPAFC/article|oldid=592507}}
 
 {{WikiProject Women}}
 {{WikiProject Women's sport}}
@@ -249,7 +249,7 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
 		expect( output.talkText ).toBe(
 `{{WikiProject banner shell|
-{{subst:WPAFC/article|class=|oldid=592507}}
+{{subst:WPAFC/article|oldid=592507}}
 
 {{WikiProject Women}}
 {{WikiProject Women's sport}}
@@ -274,11 +274,11 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		var existingWPBioTemplateName = null;
 		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
 		expect( output.talkText ).toBe(
-`{{WikiProject banner shell|
-{{subst:WPAFC/article|class=B|oldid=592496}}
-{{WikiProject Biography|living=yes|class=B|listas=Jones, Bob}}
-{{WikiProject Africa|class=B}}
-{{WikiProject Alabama|class=B}}
+`{{WikiProject banner shell|class=B|
+{{subst:WPAFC/article|oldid=592496}}
+{{WikiProject Biography|living=yes|listas=Jones, Bob}}
+{{WikiProject Africa}}
+{{WikiProject Alabama}}
 }}
 
 `
@@ -302,8 +302,8 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
 		expect( output.talkText ).toBe(
 `{{WikiProject banner shell|
-{{subst:WPAFC/article|class=|oldid=592496}}
-{{WikiProject Biography|living=no|class=|listas=}}
+{{subst:WPAFC/article|oldid=592496}}
+{{WikiProject Biography|living=no|listas=}}
 }}
 
 `
@@ -342,9 +342,9 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
 		expect( output.talkText ).toBe(
 `{{WikiProject banner shell|
-{{subst:WPAFC/article|class=|oldid=592496}}
+{{subst:WPAFC/article|oldid=592496}}
 
-{{wikiproject biography|living=yes|class=B|listas=Jones, Bob}}
+{{wikiproject biography|living=yes|listas=Jones, Bob}}
 {{WikiProject Somalia}}
 }}`
 		);
@@ -366,9 +366,9 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		var existingWPBioTemplateName = null;
 		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
 		expect( output.talkText ).toBe(
-`{{WikiProject banner shell|
-{{subst:WPAFC/article|class=disambig|oldid=592681}}
-{{WikiProject Disambiguation|class=disambig}}
+`{{WikiProject banner shell|class=disambig|
+{{subst:WPAFC/article|oldid=592681}}
+{{WikiProject Disambiguation}}
 }}
 
 `

--- a/tests/test-core.js
+++ b/tests/test-core.js
@@ -133,13 +133,19 @@ describe( 'AFCH.addTalkPageBanners', function () {
 		var alreadyHasWPBio = false;
 		var existingWPBioTemplateName = null;
 		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
-		expect( output.talkText ).toBe( '{{subst:WPAFC/article|class=|oldid=592485}}\n\n' );
+		expect( output.talkText ).toBe(
+`{{subst:WPAFC/article|class=|oldid=592485}}
+
+`
+		);
 		expect( output.countOfWikiProjectsAdded ).toBe( 0 );
 		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
 	} );
 
 	it( 'talk page has existing sections', function () {
-		var talkText = '== Hello ==\nI have a question. Can you help answer it? –[[User:Novem Linguae|<span style="color:blue">\'\'\'Novem Linguae\'\'\'</span>]] <small>([[User talk:Novem Linguae|talk]])</small> 20:22, 10 April 2024 (UTC)';
+		var talkText =
+`== Hello ==
+I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="color:blue">'''Novem Linguae'''</span>]] <small>([[User talk:Novem Linguae|talk]])</small> 20:22, 10 April 2024 (UTC)`;
 		var newAssessment = '';
 		var revId = 592485;
 		var isBiography = false;
@@ -150,14 +156,22 @@ describe( 'AFCH.addTalkPageBanners', function () {
 		var alreadyHasWPBio = false;
 		var existingWPBioTemplateName = null;
 		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
-		expect( output.talkText ).toBe( '{{subst:WPAFC/article|class=|oldid=592485}}\n\n== Hello ==\nI have a question. Can you help answer it? –[[User:Novem Linguae|<span style="color:blue">\'\'\'Novem Linguae\'\'\'</span>]] <small>([[User talk:Novem Linguae|talk]])</small> 20:22, 10 April 2024 (UTC)' );
+		expect( output.talkText ).toBe(
+`{{subst:WPAFC/article|class=|oldid=592485}}
+
+== Hello ==
+I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="color:blue">'''Novem Linguae'''</span>]] <small>([[User talk:Novem Linguae|talk]])</small> 20:22, 10 April 2024 (UTC)`
+		);
 		expect( output.countOfWikiProjectsAdded ).toBe( 0 );
 		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
 	} );
 
 	// FIXME: unexpected \n between new banners and old banners. https://github.com/wikimedia-gadgets/afc-helper/issues/330
 	it( 'talk page has existing WikiProject banners', function () {
-		var talkText = '{{WikiProject Women}}\n{{WikiProject Women\'s sport}}\n{{WikiProject Somalia}}';
+		var talkText =
+`{{WikiProject Women}}
+{{WikiProject Women's sport}}
+{{WikiProject Somalia}}`;
 		var newAssessment = '';
 		var revId = 592507;
 		var isBiography = false;
@@ -184,14 +198,23 @@ describe( 'AFCH.addTalkPageBanners', function () {
 		var alreadyHasWPBio = false;
 		var existingWPBioTemplateName = null;
 		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
-		expect( output.talkText ).toBe( '{{subst:WPAFC/article|class=|oldid=592507}}\n\n{{WikiProject Women}}\n{{WikiProject Women\'s sport}}\n{{WikiProject Somalia}}' );
+		expect( output.talkText ).toBe(
+`{{subst:WPAFC/article|class=|oldid=592507}}
+
+{{WikiProject Women}}
+{{WikiProject Women's sport}}
+{{WikiProject Somalia}}`
+		);
 		expect( output.countOfWikiProjectsAdded ).toBe( 0 );
 		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
 	} );
 
 	// FIXME: the edit summary of 1 WikiProject banner removed is correct, but this doesn't actually remove the WikiProject banner from the talk page. https://github.com/wikimedia-gadgets/afc-helper/issues/329
 	it( 'remove an existing WikiProject', function () {
-		var talkText = '{{WikiProject Women}}\n{{WikiProject Women\'s sport}}\n{{WikiProject Somalia}}';
+		var talkText =
+`{{WikiProject Women}}
+{{WikiProject Women's sport}}
+{{WikiProject Somalia}}`;
 		var newAssessment = '';
 		var revId = 592507;
 		var isBiography = false;
@@ -219,7 +242,13 @@ describe( 'AFCH.addTalkPageBanners', function () {
 		var alreadyHasWPBio = false;
 		var existingWPBioTemplateName = null;
 		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
-		expect( output.talkText ).toBe( '{{subst:WPAFC/article|class=|oldid=592507}}\n\n{{WikiProject Women}}\n{{WikiProject Women\'s sport}}\n{{WikiProject Somalia}}' );
+		expect( output.talkText ).toBe(
+`{{subst:WPAFC/article|class=|oldid=592507}}
+
+{{WikiProject Women}}
+{{WikiProject Women's sport}}
+{{WikiProject Somalia}}`
+		);
 		expect( output.countOfWikiProjectsAdded ).toBe( 0 );
 		expect( output.countOfWikiProjectsRemoved ).toBe( 1 );
 	} );
@@ -236,7 +265,14 @@ describe( 'AFCH.addTalkPageBanners', function () {
 		var alreadyHasWPBio = false;
 		var existingWPBioTemplateName = null;
 		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
-		expect( output.talkText ).toBe( '{{subst:WPAFC/article|class=B|oldid=592496}}\n{{WikiProject Biography|living=yes|class=B|listas=Jones, Bob}}\n{{WikiProject Africa|class=B}}\n{{WikiProject Alabama|class=B}}\n\n' );
+		expect( output.talkText ).toBe(
+`{{subst:WPAFC/article|class=B|oldid=592496}}
+{{WikiProject Biography|living=yes|class=B|listas=Jones, Bob}}
+{{WikiProject Africa|class=B}}
+{{WikiProject Alabama|class=B}}
+
+`
+		);
 		expect( output.countOfWikiProjectsAdded ).toBe( 2 );
 		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
 	} );
@@ -253,7 +289,12 @@ describe( 'AFCH.addTalkPageBanners', function () {
 		var alreadyHasWPBio = false;
 		var existingWPBioTemplateName = null;
 		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
-		expect( output.talkText ).toBe( '{{subst:WPAFC/article|class=|oldid=592496}}\n{{WikiProject Biography|living=no|class=|listas=}}\n\n' );
+		expect( output.talkText ).toBe(
+`{{subst:WPAFC/article|class=|oldid=592496}}
+{{WikiProject Biography|living=no|class=|listas=}}
+
+`
+		);
 		expect( output.countOfWikiProjectsAdded ).toBe( 0 );
 		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
 	} );
@@ -261,7 +302,9 @@ describe( 'AFCH.addTalkPageBanners', function () {
 	// FIXME: is supposed to remove the {{wikiproject biography}} template and report 1 template removed, but does not. code outside of AFCH.addTalkPageBanners() is incorrectly calculating alreadyHasWPBio as false
 	// FIXME: 2 extra line breaks in the output
 	it( 'talk page has {{wikiproject biography}}, and user selects that it\'s not a biography, so should remove {{wikiproject biography}}', function () {
-		var talkText = '{{wikiproject biography|living=yes|class=B|listas=Jones, Bob}}\n{{WikiProject Somalia}}';
+		var talkText =
+`{{wikiproject biography|living=yes|class=B|listas=Jones, Bob}}
+{{WikiProject Somalia}}`;
 		var newAssessment = '';
 		var revId = 592496;
 		var isBiography = false;
@@ -283,7 +326,12 @@ describe( 'AFCH.addTalkPageBanners', function () {
 		var alreadyHasWPBio = false;
 		var existingWPBioTemplateName = null;
 		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
-		expect( output.talkText ).toBe( '{{subst:WPAFC/article|class=|oldid=592496}}\n\n{{wikiproject biography|living=yes|class=B|listas=Jones, Bob}}\n{{WikiProject Somalia}}' );
+		expect( output.talkText ).toBe(
+`{{subst:WPAFC/article|class=|oldid=592496}}
+
+{{wikiproject biography|living=yes|class=B|listas=Jones, Bob}}
+{{WikiProject Somalia}}`
+		);
 		expect( output.countOfWikiProjectsAdded ).toBe( 0 );
 		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
 	} );
@@ -300,7 +348,12 @@ describe( 'AFCH.addTalkPageBanners', function () {
 		var alreadyHasWPBio = false;
 		var existingWPBioTemplateName = null;
 		var output = AFCH.addTalkPageBanners( talkText, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName, existingWikiProjects, alreadyHasWPBio, existingWPBioTemplateName );
-		expect( output.talkText ).toBe( '{{subst:WPAFC/article|class=disambig|oldid=592681}}\n{{WikiProject Disambiguation|class=disambig}}\n\n' );
+		expect( output.talkText ).toBe(
+`{{subst:WPAFC/article|class=disambig|oldid=592681}}
+{{WikiProject Disambiguation|class=disambig}}
+
+`
+		);
 		expect( output.countOfWikiProjectsAdded ).toBe( 1 );
 		expect( output.countOfWikiProjectsRemoved ).toBe( 0 );
 	} );


### PR DESCRIPTION
- Fix #319 Implement WP:PIQA (put the article's class rating in the banner shell instead of in the wikiproject templates)
- Fix #73 Multiple WikiProject banners should be collapsed in {{WikiProject banner shell}}
- In unit tests, switch from single quotes to backticks, for increased multi-line readability.