### PR TITLE
add more eslint-config-wikimedia rules. apply autofixes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+server.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,9 @@
 {
-	"extends": "wikimedia",
+	"extends": [
+		"wikimedia/client/es6",
+		"wikimedia/jquery",
+		"wikimedia/mediawiki"
+	],
 	"env": {
 		"browser": true,
 		"jquery": true
@@ -25,15 +29,31 @@
 	"rules": {
 		"camelcase": "off",
 		"eqeqeq": "warn",
+		"es-x/no-array-prototype-includes": "warn",
+		"es-x/no-object-values": "warn",
+		"es-x/no-regexp-s-flag": "warn",
 		"max-len": "off",
 		"no-console": "off",
 		"no-global-assign": "warn",
 		"no-implicit-globals": "warn",
+		"no-jquery/no-animate": "warn",
+		"no-jquery/no-class-state": "off",
+		"no-jquery/no-each-util": "warn",
+		"no-jquery/no-extend": "off",
+		"no-jquery/no-global-selector": "off",
+		"no-jquery/no-grep": "warn",
+		"no-jquery/no-in-array": "warn",
+		"no-jquery/no-map-util": "warn",
+		"no-jquery/no-sizzle": "warn",
+		"no-jquery/no-slide": "warn",
+		"no-jquery/no-trim": "warn",
+		"no-jquery/variable-pattern": "warn",
 		"no-new": "warn",
 		"no-prototype-builtins": "off",
 		"no-shadow": "off",
 		"no-undef": "warn",
 		"no-underscore-dangle": "off",
+		"prefer-const": "warn",
 		"security/detect-non-literal-regexp": "off",
 		"security/detect-unsafe-regex": "off",
 		"unicorn/prefer-string-slice": "off"

--- a/src/afch.js
+++ b/src/afch.js
@@ -3,8 +3,8 @@
 	// Check that we're in the right namespace and on the right page
 	switch ( mw.config.get( 'wgNamespaceNumber' ) ) {
 		case 4: // Wikipedia
-		case 5: // Wikipedia talk
-			var pageName = mw.config.get( 'wgTitle' );
+		case 5: { // Wikipedia talk
+			const pageName = mw.config.get( 'wgTitle' );
 			// return nothing for now, all drafts are now under Draft namespace
 			// currently only the article submission script is running here.
 			// to be used when script(s) for other modules such as category and
@@ -13,6 +13,7 @@
 				return;
 			}
 			break;
+		}
 		case 2: // User
 		case 118: // Draft
 			break;
@@ -35,8 +36,8 @@
 	AFCH.consts.baseurl = AFCH.consts.scriptpath +
 		'?action=raw&ctype=text/javascript&title=MediaWiki:Gadget-afch.js';
 
-	$.getScript( AFCH.consts.baseurl + '/core.js' ).done( function () {
-		var loaded = AFCH.load( 'submissions' ); // perhaps eventually there will be more modules besides just 'submissions'
+	$.getScript( AFCH.consts.baseurl + '/core.js' ).done( () => {
+		const loaded = AFCH.load( 'submissions' ); // perhaps eventually there will be more modules besides just 'submissions'
 		if ( !loaded ) {
 			mw.notify( 'AFCH could not be loaded: ' + ( AFCH.error || 'unknown error' ),
 				{ title: 'AFCH error' } );

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -8,7 +8,7 @@
 		 * @param {any} thing(s)
 		 */
 		log: function () {
-			var args = Array.prototype.slice.call( arguments );
+			const args = Array.prototype.slice.call( arguments );
 
 			if ( AFCH.consts.beta && console && console.log ) {
 				args.unshift( 'AFCH:' );
@@ -38,7 +38,7 @@
 		 * destroy functions by running AFCH.addDestroyFunction( fn )
 		 */
 		destroy: function () {
-			$.each( AFCH._destroyFunctions, function ( _, fn ) {
+			$.each( AFCH._destroyFunctions, ( _, fn ) => {
 				fn();
 			} );
 
@@ -113,15 +113,15 @@
 		 * if not, display an error and destroy AFCH
 		 */
 		checkWhitelist: function () {
-			var user = AFCH.consts.user,
+			const user = AFCH.consts.user,
 				whitelist = new AFCH.Page( AFCH.consts.whitelistTitle );
-			whitelist.getText().done( function ( text ) {
+			whitelist.getText().done( ( text ) => {
 
 				// sanitizedUser is user, but escaped for use in the regex.
 				// Otherwise a user named ... would always be able to use
 				// the script, so long as there was a user whose name was
 				// three characters long on the list!
-				var $howToDisable,
+				let $howToDisable,
 					sanitizedUser = user.replace( /[-[\]/{}()*+?.\\^$|]/g, '\\$&' ),
 					userSysop = $.inArray( 'sysop', mw.config.get( 'wgUserGroups' ) ) > -1,
 					userNPP = $.inArray( 'patroller', mw.config.get( 'wgUserGroups' ) ) > -1,
@@ -137,14 +137,14 @@
 							.append( 'If you wish to disable the helper script, ' )
 							.append( $( '<a>' )
 								.text( 'click here' )
-								.click( function () {
+								.on( 'click', () => {
 									// Submit the API request to disable the gadget.
 									// Note: We don't use `AFCH.api` here, because AFCH has already
 									// been destroyed due to the user not being on the whitelist!
 									( new mw.Api() ).postWithEditToken( {
 										action: 'options',
 										change: 'gadget-afchelper=0'
-									} ).done( function () {
+									} ).done( () => {
 										mw.notify( 'AFCH has been disabled successfully. If you wish to re-enable it in the ' +
 											'future, you can do so via your Preferences by checking "Yet Another AFC Helper Script".' );
 									} );
@@ -195,7 +195,7 @@
 				return false;
 			}
 
-			var promise = $.when();
+			let promise = $.when();
 
 			if ( AFCH.consts.beta ) {
 				// Load minified css
@@ -212,7 +212,7 @@
 			}
 
 			// And finally load the subscript
-			promise.then( function () {
+			promise.then( () => {
 				$.getScript( AFCH.consts.baseurl + '/' + type + '.js' );
 			} );
 
@@ -225,7 +225,7 @@
 		 * @param {string} name
 		 */
 		Page: function ( name ) {
-			var pg = this;
+			const pg = this;
 
 			this.title = new mw.Title( name );
 			this.rawTitle = this.title.getPrefixedText();
@@ -238,10 +238,10 @@
 			};
 
 			this.edit = function ( options ) {
-				var deferred = $.Deferred();
+				const deferred = $.Deferred();
 
 				AFCH.actions.editPage( this.rawTitle, options )
-					.done( function ( data ) {
+					.done( ( data ) => {
 						deferred.resolve( data );
 					} );
 
@@ -257,7 +257,7 @@
 			 * @return {jQuery.Deferred} resolves when data set successfully
 			 */
 			this._revisionApiRequest = function ( usecache ) {
-				var deferred = $.Deferred();
+				const deferred = $.Deferred();
 
 				if ( usecache && pg.hasAdditionalData ) {
 					return deferred.resolve();
@@ -267,7 +267,7 @@
 					hide: true,
 					moreProps: 'timestamp|user|ids',
 					moreParameters: { rvgeneratexml: true }
-				} ).done( function ( pagetext, data ) {
+				} ).done( ( pagetext, data ) => {
 					// Set internal data
 					pg.pageText = pagetext;
 					pg.additionalData.lastModified = new Date( data.timestamp );
@@ -291,9 +291,9 @@
 			 * @return {string}
 			 */
 			this.getText = function ( usecache ) {
-				var deferred = $.Deferred();
+				const deferred = $.Deferred();
 
-				this._revisionApiRequest( usecache ).done( function () {
+				this._revisionApiRequest( usecache ).done( () => {
 					deferred.resolve( pg.pageText );
 				} );
 
@@ -310,15 +310,15 @@
 			 *                       }
 			 */
 			this.getTemplates = function () {
-				var $templateDom, templates = [],
+				let $templateDom, templates = [],
 					deferred = $.Deferred();
 
-				this._revisionApiRequest( true ).done( function () {
+				this._revisionApiRequest( true ).done( () => {
 					$templateDom = $( $.parseXML( pg.additionalData.rawTemplateModel ) ).find( 'root' );
 
 					// We only want top level templates
 					$templateDom.children( 'template' ).each( function () {
-						var $el = $( this ),
+						const $el = $( this ),
 							data = {
 								target: $el.children( 'title' ).text(),
 								params: {}
@@ -336,7 +336,7 @@
 						 * @return {string}
 						 */
 						function parseValue( $v ) {
-							var text = AFCH.jQueryToHtml( $v );
+							let text = AFCH.jQueryToHtml( $v );
 
 							// Convert templates to look more template-y
 							text = text.replace( /<template>/g, '{{' );
@@ -352,7 +352,7 @@
 						}
 
 						$el.children( 'part' ).each( function () {
-							var $part = $( this ),
+							const $part = $( this ),
 								$name = $part.children( 'name' ),
 								// Use the name if set, or fall back to index if implicitly numbered
 								name = $.trim( $name.text() || $name.attr( 'index' ) ),
@@ -380,22 +380,20 @@
 			 * @return {Array}
 			 */
 			this.getCategories = function ( useApi, includeCategoryLinks ) {
-				var deferred = $.Deferred(),
+				const deferred = $.Deferred(),
 					text = this.pageText;
 
 				if ( useApi ) {
-					AFCH.api.getCategories( this.title ).done( function ( categories ) {
+					AFCH.api.getCategories( this.title ).done( ( categories ) => {
 						// The api returns mw.Title objects, so we convert them to simple
 						// strings before resolving the deferred.
-						deferred.resolve( categories ? $.map( categories, function ( cat ) {
-							return cat.getPrefixedText();
-						} ) : [] );
+						deferred.resolve( categories ? $.map( categories, ( cat ) => cat.getPrefixedText() ) : [] );
 					} );
 					return deferred;
 				}
 
-				this._revisionApiRequest( true ).done( function () {
-					var catRegex = new RegExp( '\\[\\[' + ( includeCategoryLinks ? ':?' : '' ) + 'Category:(.*?)\\s*\\]\\]', 'gi' ),
+				this._revisionApiRequest( true ).done( () => {
+					let catRegex = new RegExp( '\\[\\[' + ( includeCategoryLinks ? ':?' : '' ) + 'Category:(.*?)\\s*\\]\\]', 'gi' ),
 						match = catRegex.exec( text ),
 						categories = [];
 
@@ -417,15 +415,13 @@
 					prop: 'description',
 					titles: this.rawTitle,
 					formatversion: 2
-				} ).then( function ( json ) {
-					return json.query.pages[ 0 ].description || '';
-				} );
+				} ).then( ( json ) => json.query.pages[ 0 ].description || '' );
 			};
 
 			this.getLastModifiedDate = function () {
-				var deferred = $.Deferred();
+				const deferred = $.Deferred();
 
-				this._revisionApiRequest( true ).done( function () {
+				this._revisionApiRequest( true ).done( () => {
 					deferred.resolve( pg.additionalData.lastModified );
 				} );
 
@@ -433,9 +429,9 @@
 			};
 
 			this.getLastEditor = function () {
-				var deferred = $.Deferred();
+				const deferred = $.Deferred();
 
-				this._revisionApiRequest( true ).done( function () {
+				this._revisionApiRequest( true ).done( () => {
 					deferred.resolve( pg.additionalData.lastEditor );
 				} );
 
@@ -443,7 +439,7 @@
 			};
 
 			this.getCreator = function () {
-				var request, deferred = $.Deferred();
+				let request, deferred = $.Deferred();
 
 				if ( this.additionalData.creator ) {
 					deferred.resolve( this.additionalData.creator );
@@ -462,8 +458,8 @@
 
 				// FIXME: Handle failure more gracefully
 				AFCH.api.get( request )
-					.done( function ( data ) {
-						var rev, id = data.query.pageids[ 0 ];
+					.done( ( data ) => {
+						let rev, id = data.query.pageids[ 0 ];
 						if ( id && data.query.pages[ id ] ) {
 							rev = data.query.pages[ id ].revisions[ 0 ];
 							pg.additionalData.creator = rev.user;
@@ -477,13 +473,13 @@
 			};
 
 			this.exists = function () {
-				var deferred = $.Deferred();
+				const deferred = $.Deferred();
 
 				AFCH.api.get( {
 					action: 'query',
 					prop: 'info',
 					titles: this.rawTitle
-				} ).done( function ( data ) {
+				} ).done( ( data ) => {
 					// A nonexistent page will be indexed as '-1'
 					if ( data.query.pages.hasOwnProperty( '-1' ) ) {
 						deferred.resolve( false );
@@ -501,7 +497,7 @@
 			 * @return {AFCH.Page}
 			 */
 			this.getTalkPage = function () {
-				var title, ns = this.title.getNamespaceId();
+				let title, ns = this.title.getNamespaceId();
 
 				// Odd-numbered namespaces are already talk namespaces
 				if ( ns % 2 !== 0 ) {
@@ -529,7 +525,7 @@
 			 * @return {jQuery.Deferred} Resolves with pagetext and full data available as parameters
 			 */
 			getPageText: function ( pagename, options ) {
-				var status, request, rvprop = 'content',
+				let status, request, rvprop = 'content',
 					deferred = $.Deferred();
 
 				if ( !options.hide ) {
@@ -555,8 +551,8 @@
 				$.extend( request, options.moreParameters || {} );
 
 				AFCH.api.get( request )
-					.done( function ( data ) {
-						var rev, id = data.query.pageids[ 0 ];
+					.done( ( data ) => {
+						let rev, id = data.query.pageids[ 0 ];
 						if ( id && data.query.pages ) {
 							// The page might not exist; resolve with an empty string
 							if ( id === '-1' ) {
@@ -573,7 +569,7 @@
 							status.update( 'Error getting $1: ' + JSON.stringify( data ) );
 						}
 					} )
-					.fail( function ( err ) {
+					.fail( ( err ) => {
 						deferred.reject( err );
 						status.update( 'Error getting $1: ' + JSON.stringify( err ) );
 					} );
@@ -599,7 +595,7 @@
 			 * @return {jQuery.Deferred} Resolves if saved with all data
 			 */
 			editPage: function ( pagename, options ) {
-				var status, request, deferred = $.Deferred();
+				let status, request, deferred = $.Deferred();
 
 				if ( !options ) {
 					options = {};
@@ -665,11 +661,11 @@
 				}
 
 				AFCH.api.postWithEditToken( request )
-					.done( function ( data ) {
-						var $diffLink;
-						var api = options.subscribe ? 'discussiontoolsedit' : 'edit';
+					.done( ( data ) => {
+						let $diffLink;
+						const api = options.subscribe ? 'discussiontoolsedit' : 'edit';
 						// The success string is capitalized by one API and not the other
-						var success = options.subscribe ? 'success' : 'Success';
+						const success = options.subscribe ? 'success' : 'Success';
 
 						if ( data && data[ api ] && data[ api ].result && data[ api ].result === success ) {
 							deferred.resolve( data );
@@ -691,7 +687,7 @@
 							status.update( 'Error while saving $1: ' + JSON.stringify( data ) );
 						}
 					} )
-					.fail( function ( err ) {
+					.fail( ( err ) => {
 						deferred.reject( err );
 						status.update( 'Error while saving $1: ' + JSON.stringify( err ) );
 					} );
@@ -710,7 +706,7 @@
 			 * @return {jQuery.Deferred} Resolves with success/failure
 			 */
 			movePage: function ( oldTitle, newTitle, reason, additionalParameters, hide ) {
-				var status, request, deferred = $.Deferred();
+				let status, request, deferred = $.Deferred();
 
 				if ( !hide ) {
 					status = new AFCH.status.Element( 'Moving $1 to $2...', {
@@ -739,7 +735,7 @@
 				}
 
 				AFCH.api.postWithEditToken( request ) // Move token === edit token
-					.done( function ( data ) {
+					.done( ( data ) => {
 						if ( data && data.move ) {
 							status.update( 'Moved $1 to $2' );
 							deferred.resolve( data.move );
@@ -749,7 +745,7 @@
 							deferred.reject( data.error );
 						}
 					} )
-					.fail( function ( err ) {
+					.fail( ( err ) => {
 						status.update( 'Error moving $1 to $2: ' + JSON.stringify( err ) );
 						deferred.reject( err );
 					} );
@@ -769,10 +765,10 @@
 			 * @return {jQuery.Deferred} Resolves with success/failure
 			 */
 			notifyUser: function ( user, options ) {
-				var deferred = $.Deferred(),
+				const deferred = $.Deferred(),
 					userTalkPage = new AFCH.Page( new mw.Title( user, 3 ).getPrefixedText() ); // 3 = user talk namespace
 
-				userTalkPage.exists().done( function ( exists ) {
+				userTalkPage.exists().done( ( exists ) => {
 					userTalkPage.edit( {
 						contents: ( exists ? '' : '{{Talk header}}' ) + '\n\n' + options.message,
 						summary: options.summary || 'Notifying user',
@@ -782,10 +778,10 @@
 						followRedirects: true,
 						subscribe: AFCH.prefs.autoSubscribe
 					} )
-						.done( function () {
+						.done( () => {
 							deferred.resolve();
 						} )
-						.fail( function () {
+						.fail( () => {
 							deferred.reject();
 						} );
 				} );
@@ -803,7 +799,7 @@
 			 * @return {jQuery.Deferred|void} resolves false if the page did not exist, otherwise resolves/rejects with data from the edit
 			 */
 			logCSD: function ( options ) {
-				var deferred = $.Deferred(),
+				const deferred = $.Deferred(),
 					logPage = new AFCH.Page( 'User:' + mw.config.get( 'wgUserName' ) + '/' +
 						( window.Twinkle && window.Twinkle.getPref( 'speedyLogPageName' ) || 'CSD log' ) );
 
@@ -812,7 +808,7 @@
 					return;
 				}
 
-				logPage.getText().done( function ( logText ) {
+				logPage.getText().done( ( logText ) => {
 
 					// Don't edit if the page has doesn't exist or has no text
 					if ( !logText ) {
@@ -820,14 +816,14 @@
 						return;
 					}
 
-					var appendText = AFCH.actions.addLogHeaderIfNeeded( logText );
+					let appendText = AFCH.actions.addLogHeaderIfNeeded( logText );
 
 					appendText += '\n# [[:' + options.title + ']]: ' + options.reason;
 
 					if ( options.usersNotified && options.usersNotified.length ) {
 						appendText += '; notified {{user|1=' + options.usersNotified.shift() + '}}';
 
-						$.each( options.usersNotified, function ( _, user ) {
+						$.each( options.usersNotified, ( _, user ) => {
 							appendText += ', {{user|1=' + user + '}}';
 						} );
 					}
@@ -839,9 +835,9 @@
 						mode: 'appendtext',
 						summary: 'Logging speedy deletion nomination of [[' + options.title + ']]',
 						statusText: 'Logging speedy deletion nomination to'
-					} ).done( function ( data ) {
+					} ).done( ( data ) => {
 						deferred.resolve( data );
-					} ).fail( function ( data ) {
+					} ).fail( ( data ) => {
 						deferred.reject( data );
 					} );
 				} );
@@ -850,7 +846,7 @@
 			},
 
 			logAfc: function ( options ) {
-				var deferred = $.Deferred(),
+				const deferred = $.Deferred(),
 					logPage = new AFCH.Page( 'User:' + mw.config.get( 'wgUserName' ) + '/AfC log' );
 
 				// Abort if user disabled in preferences
@@ -858,14 +854,14 @@
 					return;
 				}
 
-				logPage.getText().done( function ( logText ) {
+				logPage.getText().done( ( logText ) => {
 					// Build log message
-					var header = AFCH.actions.addLogHeaderIfNeeded( logText );
-					var action = '\n# ' + options.actionType.charAt( 0 ).toUpperCase() + options.actionType.slice( 1 ) +
+					const header = AFCH.actions.addLogHeaderIfNeeded( logText );
+					const action = '\n# ' + options.actionType.charAt( 0 ).toUpperCase() + options.actionType.slice( 1 ) +
 										( options.actionType === 'decline' ? '' : 'e' ) + 'd';
-					var title = ' [[:' + options.title + ']]';
+					const title = ' [[:' + options.title + ']]';
 
-					var declineReason = '';
+					let declineReason = '';
 					if ( options.actionType === 'decline' ) {
 						// Custom is stored as 'reason' (because of template weirdness?), convert if necessary
 						options.declineReason = ( options.declineReason === 'reason' ) ? 'custom' : options.declineReason;
@@ -874,8 +870,8 @@
 						declineReason = ' (' + options.declineReason + ( options.declineReason2 ? ' & ' + options.declineReason2 : '' ) + ')';
 					}
 
-					var byUser = ' by [[User:' + options.submitter + '|]]';
-					var sig = ' ~~~~~\n';
+					const byUser = ' by [[User:' + options.submitter + '|]]';
+					const sig = ' ~~~~~\n';
 
 					// Make log edit
 					logPage.edit( {
@@ -883,9 +879,9 @@
 						mode: 'appendtext',
 						summary: 'Logging ' + options.actionType + ' of [[' + options.title + ']]',
 						statusText: 'Logging ' + options.actionType + ' to'
-					} ).done( function ( data ) {
+					} ).done( ( data ) => {
 						deferred.resolve( data );
-					} ).fail( function ( data ) {
+					} ).fail( ( data ) => {
 						deferred.reject( data );
 					} );
 				} );
@@ -901,7 +897,7 @@
 			 * @return {string} headerText
 			 */
 			addLogHeaderIfNeeded: function ( logText ) {
-				var date = new Date(),
+				let date = new Date(),
 					monthNames = [ 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December' ],
 					headerRe = new RegExp( '^==+\\s*' + monthNames[ date.getUTCMonth() ] + '\\s+' + date.getUTCFullYear() + '\\s*==+', 'm' ),
 					headerText = '';
@@ -922,7 +918,7 @@
 			 * @return {jQuery.Deferred}
 			 */
 			patrolRcid: function ( rcid, title ) {
-				var request, deferred = $.Deferred(),
+				let request, deferred = $.Deferred(),
 					status = new AFCH.status.Element( 'Patrolling $1...',
 						{ $1: AFCH.makeLinkElementToPage( title ) || 'page with id #' + rcid } );
 
@@ -937,7 +933,7 @@
 					return deferred;
 				}
 
-				AFCH.api.postWithToken( 'patrol', request ).done( function ( data ) {
+				AFCH.api.postWithToken( 'patrol', request ).done( ( data ) => {
 					if ( data.patrol && data.patrol.rcid ) {
 						status.update( 'Patrolled $1' );
 						deferred.resolve( data );
@@ -945,7 +941,7 @@
 						status.update( 'Failed to patrol $1: ' + JSON.stringify( data.patrol ) );
 						deferred.reject( data );
 					}
-				} ).fail( function ( data ) {
+				} ).fail( ( data ) => {
 					status.update( 'Failed to patrol $1: ' + JSON.stringify( data ) );
 					deferred.reject( data );
 				} );
@@ -999,7 +995,7 @@
 					}
 
 					// First run the substutions
-					$.each( this.substitutions, function ( key, value ) {
+					$.each( this.substitutions, ( key, value ) => {
 						// If we are passed a jQuery object, convert it to regular HTML first
 						if ( value.jquery ) {
 							value = AFCH.jQueryToHtml( value );
@@ -1062,11 +1058,11 @@
 			 * @return {string} Message value
 			 */
 			get: function ( key, substitutions ) {
-				var text = AFCH.msg.store[ key ] || '<' + key + '>';
+				let text = AFCH.msg.store[ key ] || '<' + key + '>';
 
 				// Perform substitutions if necessary
 				if ( substitutions ) {
-					$.each( substitutions, function ( original, replacement ) {
+					$.each( substitutions, ( original, replacement ) => {
 						text = text.replace(
 							// Escape the original substitution key, then make it a global regex
 							new RegExp( original.replace( /[-/\\^$*+?.()|[\]{}]/g, '\\$&' ), 'g' ),
@@ -1134,7 +1130,7 @@
 			 * @return {jQuery.Deferred} success
 			 */
 			set: function ( key, value ) {
-				var deferred = $.Deferred(),
+				const deferred = $.Deferred(),
 					fullKey = AFCH.userData._prefix + key,
 					fullValue = JSON.stringify( value );
 
@@ -1153,7 +1149,7 @@
 					action: 'options',
 					optionname: fullKey,
 					optionvalue: fullValue
-				} ).done( function ( data ) {
+				} ).done( ( data ) => {
 					deferred.resolve( data );
 				} );
 
@@ -1168,7 +1164,7 @@
 			 * @return {Mixed} value
 			 */
 			get: function ( key, fallback ) {
-				var value,
+				let value,
 					fullKey = AFCH.userData._prefix + key,
 					cachedWindow = AFCH.userData._optsCache[ fullKey ],
 					cachedLocal = window.localStorage && window.localStorage[ fullKey ];
@@ -1199,7 +1195,7 @@
 		 * @type {Object}
 		 */
 		Preferences: function () {
-			var prefs = this;
+			const prefs = this;
 
 			/**
 			 * Default values for user preferences; details for each preference can be
@@ -1227,7 +1223,7 @@
 			 * Initializes the preferences modification dialog
 			 */
 			this.initDialog = function () {
-				var $spinner = $.createSpinner( {
+				const $spinner = $.createSpinner( {
 					size: 'large',
 					type: 'block'
 				} ).css( 'padding', '20px' );
@@ -1272,7 +1268,7 @@
 						type: 'GET',
 						url: AFCH.consts.baseurl + '/tpl-preferences.js',
 						dataType: 'text'
-					} ).done( function ( data ) {
+					} ).done( ( data ) => {
 						prefs.views = new AFCH.Views( data );
 						prefs.renderMain();
 					} );
@@ -1297,7 +1293,7 @@
 
 				// Manually handle selecting the desired value in <select> menus
 				this.$dialog.find( 'select' ).each( function () {
-					var $select = $( this ),
+					const $select = $( this ),
 						id = $select.attr( 'id' ),
 						value = prefs.prefStore[ id ];
 					$select.find( 'option[value="' + value + '"]' ).prop( 'selected', true );
@@ -1316,7 +1312,7 @@
 				$.extend( this.prefStore, AFCH.getFormValues( this.$dialog.find( '.afch-input' ) ) );
 
 				// Set the new userData value
-				AFCH.userData.set( 'preferences', this.prefStore ).done( function () {
+				AFCH.userData.set( 'preferences', this.prefStore ).done( () => {
 					// When we're done, close the dialog and notify the user
 					prefs.$dialog.dialog( 'close' );
 					mw.notify( 'AFCH: Preferences saved successfully! They will take effect when the current page is ' +
@@ -1335,7 +1331,7 @@
 					.text( linkText || 'Update preferences' )
 					.addClass( 'preferences-link link' )
 					.appendTo( $element )
-					.click( function () {
+					.on( 'click', () => {
 						prefs.initDialog();
 						prefs.$dialog.dialog( 'open' );
 					} );
@@ -1360,18 +1356,18 @@
 			};
 
 			this.renderView = function ( name, data ) {
-				var view = this.views[ name ],
+				const view = this.views[ name ],
 					template = Hogan.compile( view );
 
 				return template.render( data );
 			};
 
 			this.loadFromSrc = function ( src ) {
-				var viewRegex = /<!--\s(.*?)\s-->\r?\n([\s\S]*?)<!--\s\/(.*?)\s-->/g,
+				let viewRegex = /<!--\s(.*?)\s-->\r?\n([\s\S]*?)<!--\s\/(.*?)\s-->/g,
 					match = viewRegex.exec( src );
 
 				while ( match !== null ) {
-					var key = match[ 1 ],
+					const key = match[ 1 ],
 						content = match[ 2 ];
 
 					this.setView( key, content );
@@ -1397,7 +1393,7 @@
 			this.previousState = false;
 
 			this.loadView = function ( view, data ) {
-				var code = this.views.renderView( view, data );
+				const code = this.views.renderView( view, data );
 
 				// Update the view cache
 				this.previousState = this.$element.clone( true );
@@ -1419,7 +1415,7 @@
 		 * @return {Mixed}
 		 */
 		getAndDelete: function ( object, key ) {
-			var v = object[ key ];
+			const v = object[ key ];
 			delete object[ key ];
 			return v;
 		},
@@ -1431,7 +1427,7 @@
 		 * @param {Mixed} value
 		 */
 		removeFromArray: function ( array, value ) {
-			var index = $.inArray( value, array );
+			let index = $.inArray( value, array );
 			while ( index !== -1 ) {
 				array.splice( index, 1 );
 				index = $.inArray( value, array );
@@ -1451,10 +1447,10 @@
 		 * @return {Object} object of values, with the ids as keys
 		 */
 		getFormValues: function ( $selector ) {
-			var data = {};
+			const data = {};
 
-			$selector.each( function ( _, element ) {
-				var value, allTexts,
+			$selector.each( ( _, element ) => {
+				let value, allTexts,
 					$element = $( element );
 
 				if ( element.type === 'checkbox' ) {
@@ -1499,16 +1495,16 @@
 		 * @return {jQuery} <a> element
 		 */
 		makeLinkElementToPage: function ( pagename, displayTitle, newTab, dontFollowRedirects ) {
-			var actualTitle = pagename.replace( /_/g, ' ' );
+			const actualTitle = pagename.replace( /_/g, ' ' );
 
 			// newTab is an optional parameter.
 			newTab = ( typeof newTab === 'undefined' ) ? true : newTab;
 
-			var options = {};
+			let options = {};
 			if ( dontFollowRedirects ) {
 				options = { redirect: 'no' };
 			}
-			var url = mw.util.getUrl( actualTitle, options );
+			const url = mw.util.getUrl( actualTitle, options );
 
 			return $( '<a>' )
 				.attr( 'href', url )
@@ -1526,7 +1522,7 @@
 		 * @return {jQuery} <a> element
 		 */
 		makeLinkElementToCategory: function ( pagename, displayTitle ) {
-			var linkElement = AFCH.makeLinkElementToPage( 'Special:RandomInCategory/' + pagename, displayTitle, false ),
+			const linkElement = AFCH.makeLinkElementToPage( 'Special:RandomInCategory/' + pagename, displayTitle, false ),
 				request = {
 					action: 'query',
 					titles: 'Category:' + pagename,
@@ -1541,9 +1537,9 @@
 			linkSpan.append( $( '<span>' ).attr( 'id', countSpanId ) );
 
 			AFCH.api.get( request )
-				.done( function ( data ) {
+				.done( ( data ) => {
 					if ( data.query.pages && !data.query.pages[ '-1' ] ) {
-						var pageKey = Object.keys( data.query.pages )[ 0 ],
+						const pageKey = Object.keys( data.query.pages )[ 0 ],
 							pagesCount = data.query.pages[ pageKey ].categoryinfo.pages;
 						$( '#' + countSpanId ).text( ' (' + pagesCount + ')' );
 
@@ -1562,12 +1558,12 @@
 		 * @return {string}
 		 */
 		convertWikilinksToHTML: function ( wikicode ) {
-			var newCode = wikicode,
+			let newCode = wikicode,
 				wikilinkRegex = /\[\[(.*?)\s*(?:\|\s*(.*?))?\]\]/g,
 				wikilinkMatch = wikilinkRegex.exec( wikicode );
 
 			while ( wikilinkMatch ) {
-				var title = wikilinkMatch[ 1 ],
+				const title = wikilinkMatch[ 1 ],
 					displayTitle = wikilinkMatch[ 2 ],
 					newLink = AFCH.makeLinkElementToPage( title, displayTitle );
 
@@ -1593,19 +1589,19 @@
 			// Hard to write a regex that doesn't catastrophic backtrack while still saving multiple categories and multiple blank lines. So we'll do this the old-fashioned way...
 
 			// Divide wikitext into lines
-			var lines = wikicode.split( '\n' );
+			let lines = wikicode.split( '\n' );
 
 			// Buffers
-			var linesToKeep = [];
-			var i;
+			const linesToKeep = [];
+			let i;
 
 			// Crawl the list of lines backward (bottom up)
-			var count = lines.length;
+			let count = lines.length;
 			for ( i = count - 1; i >= 0; i-- ) {
-				var line = lines[ i ];
-				var isWhitespace = line.match( /^\s*$/ );
-				var isCategory = line.match( /^\s*\[\[:?Category:/i );
-				var isHeading = line.match( /^==[^=]+==$/i );
+				const line = lines[ i ];
+				const isWhitespace = line.match( /^\s*$/ );
+				const isCategory = line.match( /^\s*\[\[:?Category:/i );
+				const isHeading = line.match( /^==[^=]+==$/i );
 
 				if ( isWhitespace || isCategory ) {
 					linesToKeep.push( line );
@@ -1624,8 +1620,8 @@
 			// Add the categories and blank lines back
 			// Need to iterate backward, same as the loop above
 			count = linesToKeep.length;
-			for ( var j = count - 1; j >= 0; j-- ) {
-				var lineToKeep = linesToKeep[ j ];
+			for ( let j = count - 1; j >= 0; j-- ) {
+				const lineToKeep = linesToKeep[ j ];
 				lines.push( lineToKeep );
 			}
 
@@ -1652,18 +1648,18 @@
 		 */
 		addTalkPageBanners: function ( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName ) {
 			// build an array of all banners already on page
-			var bannerTemplates = 'wikiproject (?!banner)|football|oka';
-			var bannerTemplateRegEx = new RegExp( '{{(?:' + bannerTemplates + ')[^}]*}}', 'gi' );
-			var banners = wikicode.match( bannerTemplateRegEx ) || [];
+			const bannerTemplates = 'wikiproject (?!banner)|football|oka';
+			const bannerTemplateRegEx = new RegExp( '{{(?:' + bannerTemplates + ')[^}]*}}', 'gi' );
+			let banners = wikicode.match( bannerTemplateRegEx ) || [];
 
 			// delete all banners already on page
-			banners.forEach( function ( v ) {
+			banners.forEach( ( v ) => {
 				wikicode = wikicode.replace( v, '' );
 			} );
 
 			// delete shell already on page
-			var bannerShellTemplates = 'WikiProject banner shell|WikiProjectBanners|WikiProject Banners|WPB|WPBS|WikiProject cooperation shell|Wikiprojectbannershell|WikiProject Banner Shell|Wpb|WPBannerShell|Wpbs|Wikiprojectbanners|WP Banner Shell|WP banner shell|Bannershell|Wikiproject banner shell|WIkiProjectBanner Shell|WikiProjectBannerShell|WikiProject BannerShell|Coopshell|WikiprojectBannerShell|WikiProject Shell|Scope shell|Project shell|WikiProject shell|WikiProject banner|Wpbannershell|Multiple wikiprojects|Wikiproject banner holder|Project banner holder|WikiProject banner shell\\/test1|Article assessment|WikiProject bannershell';
-			var bannerShellRegEx = new RegExp( '{{(?:' + bannerShellTemplates + ')[^}]*}}', 'is' );
+			const bannerShellTemplates = 'WikiProject banner shell|WikiProjectBanners|WikiProject Banners|WPB|WPBS|WikiProject cooperation shell|Wikiprojectbannershell|WikiProject Banner Shell|Wpb|WPBannerShell|Wpbs|Wikiprojectbanners|WP Banner Shell|WP banner shell|Bannershell|Wikiproject banner shell|WIkiProjectBanner Shell|WikiProjectBannerShell|WikiProject BannerShell|Coopshell|WikiprojectBannerShell|WikiProject Shell|Scope shell|Project shell|WikiProject shell|WikiProject banner|Wpbannershell|Multiple wikiprojects|Wikiproject banner holder|Project banner holder|WikiProject banner shell\\/test1|Article assessment|WikiProject bannershell';
+			const bannerShellRegEx = new RegExp( '{{(?:' + bannerShellTemplates + ')[^}]*}}', 'is' );
 			wikicode = wikicode.replace( bannerShellRegEx, '' );
 
 			// trim. makes unit tests more stable
@@ -1678,9 +1674,7 @@
 			);
 
 			// delete existing biography banner. when accepting, reviewer is forced to choose if it's a biography or not, so we'll add (or not add) our own biography banner later
-			banners = banners.filter( function ( value ) {
-				return !value.match( /^{{WikiProject Biography/i );
-			} );
+			banners = banners.filter( ( value ) => !value.match( /^{{WikiProject Biography/i ) );
 
 			// add biography banner to array
 			if ( isBiography ) {
@@ -1698,7 +1692,7 @@
 			}
 
 			// add banners selected in UI to array
-			for ( var key in newWikiProjects ) {
+			for ( const key in newWikiProjects ) {
 				banners.push( '{{' + newWikiProjects[ key ] + '}}' );
 			}
 
@@ -1706,9 +1700,7 @@
 			banners = AFCH.removeDuplicateBanners( banners );
 
 			// delete |class= from banners in array
-			banners = banners.map( function ( value ) {
-				return value.replace( /\s*\|\s*class\s*=\s*[^|}]*([\n|}])/, '$1' );
-			} );
+			banners = banners.map( ( value ) => value.replace( /\s*\|\s*class\s*=\s*[^|}]*([\n|}])/, '$1' ) );
 
 			// Convert array back to wikitext and append to top of talk page.
 			// Always add a shell even if it's just wrapping one banner, for code simplification reasons.
@@ -1737,10 +1729,10 @@
 		 * @return {Array} banners [ '{{WikiProject Australia}}' ]
 		 */
 		removeDuplicateBanners: function ( banners ) {
-			var uniqueBanners = [];
-			var bannerMap = {};
-			banners.forEach( function ( banner ) {
-				var bannerKey = banner.toLowerCase().match( /{{[^|}]+/ )[ 0 ];
+			const uniqueBanners = [];
+			const bannerMap = {};
+			banners.forEach( ( banner ) => {
+				const bannerKey = banner.toLowerCase().match( /{{[^|}]+/ )[ 0 ];
 				if ( !bannerMap[ bannerKey ] ) {
 					uniqueBanners.push( banner );
 					bannerMap[ bannerKey ] = true;
@@ -1758,7 +1750,7 @@
 		 * @return {string}
 		 */
 		relativeTimeSince: function ( old, now ) {
-			var oldDate = typeof old === 'object' ? old : AFCH.mwTimestampToDate( old ),
+			let oldDate = typeof old === 'object' ? old : AFCH.mwTimestampToDate( old ),
 				nowDate = typeof now === 'object' ? now : new Date(),
 				msPerMinute = 60 * 1000,
 				msPerHour = msPerMinute * 60,
@@ -1818,7 +1810,7 @@
 			toggleState( $( elementSelector ).is( ':visible' ) );
 
 			// Add the new click handler
-			$( document ).on( 'click', toggleSelector, function () {
+			$( document ).on( 'click', toggleSelector, () => {
 				toggleState( $( elementSelector ).hasClass( 'hidden' ) );
 			} );
 		},
@@ -1844,7 +1836,7 @@
 		 * @return {Date|number}
 		 */
 		parseForTimestamp: function ( string, mwstyle ) {
-			var exp, match, date;
+			let exp, match, date;
 
 			exp = new RegExp( '(\\d{1,2}):(\\d{2}), (\\d{1,2}) ' +
 				'(January|February|March|April|May|June|July|August|September|October|November|December) ' +
@@ -1878,7 +1870,7 @@
 		 * @return {Date|boolean} if unable to parse, returns false
 		 */
 		mwTimestampToDate: function ( string ) {
-			var date, dateMatches = /(\d{4})(\d\d)(\d\d)(\d\d)(\d\d)(\d\d)/.exec( string );
+			let date, dateMatches = /(\d{4})(\d\d)(\d\d)(\d\d)(\d\d)(\d\d)/.exec( string );
 
 			// If it *isn't* actually a MediaWiki-style timestamp, pass directly to date
 			if ( dateMatches === null ) {
@@ -1935,11 +1927,11 @@
 		 * @return {jQuery.Deferred} Resolves with the requested HTML
 		 */
 		getReason: function ( code ) {
-			var deferred = $.Deferred();
+			const deferred = $.Deferred();
 
 			$.post( 'https://en.wikipedia.org/api/rest_v1/transform/wikitext/to/html',
 				'wikitext={{AFC submission/comments|' + code + '}}&body_only=true',
-				function ( data ) {
+				( data ) => {
 					deferred.resolve( data );
 				}
 			);

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1,6 +1,6 @@
 // <nowiki>
 ( function ( AFCH, $, mw ) {
-	var $afchLaunchLink, $afch, $afchWrapper,
+	let $afchLaunchLink, $afch, $afchWrapper,
 		afchPage, afchSubmission, afchViews, afchViewer;
 
 	// Die if reviewing a nonexistent page or a userjs/css page
@@ -72,10 +72,10 @@
 	 * @return {jQuery.Deferred} Resolves with the submission when parsed successfully
 	 */
 	AFCH.Submission.prototype.parse = function () {
-		var sub = this,
+		const sub = this,
 			deferred = $.Deferred();
 
-		this.page.getTemplates().done( function ( templates ) {
+		this.page.getTemplates().done( ( templates ) => {
 			sub.loadDataFromTemplates( templates );
 			sub.sortAndParseInternalData();
 			deferred.resolve( sub );
@@ -91,11 +91,11 @@
 	 */
 	AFCH.Submission.prototype.loadDataFromTemplates = function ( templates ) {
 		// Represent each AfC submission template as an object.
-		var submissionTemplates = [],
+		const submissionTemplates = [],
 			commentTemplates = [];
 
-		$.each( templates, function ( _, template ) {
-			var name = template.target.toLowerCase();
+		$.each( templates, ( _, template ) => {
+			const name = template.target.toLowerCase();
 			if ( name === 'afc submission' ) {
 				submissionTemplates.push( {
 					status: ( AFCH.getAndDelete( template.params, '1' ) || '' ).toLowerCase(),
@@ -120,7 +120,7 @@
 	 * Sort the internal lists of AFC submission and Afc comment templates
 	 */
 	AFCH.Submission.prototype.sortAndParseInternalData = function () {
-		var sub = this,
+		let sub = this,
 			submissionTemplates = this.templates,
 			commentTemplates = this.comments;
 
@@ -146,7 +146,7 @@
 		this.resetVariables();
 
 		// Useful list of "what to do" in each situation.
-		var statusCases = {
+		const statusCases = {
 			// Declined
 			d: function () {
 				if ( !sub.isPending && !sub.isDraft && !sub.isUnderReview ) {
@@ -189,8 +189,8 @@
 		// the oldest. In the process, we remove unneeded templates (for example,
 		// a draft tag when it's already been submitted) and also set various
 		// "isX" properties of the Submission.
-		submissionTemplates = $.grep( submissionTemplates, function ( template ) {
-			var keepTemplate = true;
+		submissionTemplates = $.grep( submissionTemplates, ( template ) => {
+			let keepTemplate = true;
 
 			if ( statusCases[ template.status ] ) {
 				keepTemplate = statusCases[ template.status ]();
@@ -232,12 +232,12 @@
 	 * @return {string}
 	 */
 	AFCH.Submission.prototype.makeWikicode = function () {
-		var output = [],
+		let output = [],
 			hasDeclineTemplate = false;
 
 		// Submission templates go first
-		$.each( this.templates, function ( _, template ) {
-			var tout = '{{AFC submission|' + template.status,
+		$.each( this.templates, ( _, template ) => {
+			let tout = '{{AFC submission|' + template.status,
 				paramKeys = [];
 
 			// FIXME: Think about if we really want this elaborate-ish
@@ -248,15 +248,15 @@
 			// can scrap this. Until then, though, we can only dream...
 
 			// Make an array of the parameters
-			$.each( template.params, function ( key, value ) {
+			$.each( template.params, ( key, value ) => {
 				// Parameters set to false are ignored
 				if ( value !== false ) {
 					paramKeys.push( key );
 				}
 			} );
 
-			paramKeys.sort( function ( a, b ) {
-				var aIsNumber = !isNaN( a ),
+			paramKeys.sort( ( a, b ) => {
+				const aIsNumber = !isNaN( a ),
 					bIsNumber = !isNaN( b );
 
 				// If we're passed two numerical parameters then
@@ -279,8 +279,8 @@
 				return 0;
 			} );
 
-			$.each( paramKeys, function ( index, key ) {
-				var value = template.params[ key ];
+			$.each( paramKeys, ( index, key ) => {
+				const value = template.params[ key ];
 				// If it is a numerical parameter, doesn't include
 				// `=` in the value, AND is in sequence with the other
 				// numerical parameters, we can omit the key= part
@@ -314,7 +314,7 @@
 		} );
 
 		// Then comment templates
-		$.each( this.comments, function ( _, comment ) {
+		$.each( this.comments, ( _, comment ) => {
 			output.push( '\n{{AFC comment|1=' + comment.text + '}}' );
 		} );
 
@@ -332,7 +332,7 @@
 	 * @return {jQuery.Deferred} Resolves to bool if submission is eligible
 	 */
 	AFCH.Submission.prototype.isG13Eligible = function () {
-		var deferred = $.Deferred();
+		const deferred = $.Deferred();
 
 		// Submission must not currently be submitted
 		if ( this.isCurrentlySubmitted ) {
@@ -348,8 +348,8 @@
 
 		// And not have been modified in 6 months
 		// FIXME: Ignore bot edits?
-		this.page.getLastModifiedDate().done( function ( lastEdited ) {
-			var timeNow = new Date(),
+		this.page.getLastModifiedDate().done( ( lastEdited ) => {
+			const timeNow = new Date(),
 				sixMonthsAgo = new Date();
 
 			sixMonthsAgo.setMonth( timeNow.getMonth() - 6 );
@@ -369,7 +369,7 @@
 	 * @return {boolean} success
 	 */
 	AFCH.Submission.prototype.setStatus = function ( newStatus, newParams ) {
-		var relevantTemplate = this.templates[ 0 ];
+		const relevantTemplate = this.templates[ 0 ];
 
 		if ( [ 'd', 't', 'r', '' ].indexOf( newStatus ) === -1 ) {
 			// Unrecognized status
@@ -433,7 +433,7 @@
 	 * @return {boolean} success
 	 */
 	AFCH.Submission.prototype.addNewComment = function ( text ) {
-		var commentText = addSignature( text );
+		const commentText = addSignature( text );
 
 		this.comments.unshift( {
 			// Unicorns are explained in loadDataFromTemplates()
@@ -454,7 +454,7 @@
 	 * @return {jQuery.Deferred} resolves with user
 	 */
 	AFCH.Submission.prototype.getSubmitter = function () {
-		var deferred = $.Deferred(),
+		const deferred = $.Deferred(),
 			user = this.params.u;
 
 		// Recursively detect if the user has been renamed by checking the rename log
@@ -466,21 +466,21 @@
 				letype: 'renameuser',
 				lelimit: 1,
 				letitle: 'User:' + user
-			} ).then( function ( resp ) {
-				var logevents = resp.query.logevents;
+			} ).then( ( resp ) => {
+				const logevents = resp.query.logevents;
 
 				if ( logevents.length ) {
-					var newName = logevents[ 0 ].params.newuser;
+					const newName = logevents[ 0 ].params.newuser;
 					this.params.u = newName;
-					this.getSubmitter().then( function ( user ) {
+					this.getSubmitter().then( ( user ) => {
 						deferred.resolve( user );
 					} );
 				} else {
 					deferred.resolve( user );
 				}
-			}.bind( this ) );
+			} );
 		} else {
-			this.page.getCreator().done( function ( user ) {
+			this.page.getCreator().done( ( user ) => {
 				deferred.resolve( user );
 			} );
 		}
@@ -517,7 +517,7 @@
 	};
 
 	AFCH.Text.prototype.cleanUp = function ( isAccept ) {
-		var text = this.text,
+		let text = this.text,
 			commentRegex,
 			commentsToRemove = [
 				'Please don\'t change anything and press save',
@@ -545,7 +545,7 @@
 			text = text.replace( /\[\[:Category:/gi, '[[Category:' );
 			text = text.replace( /\{\{(tl|tlx|tlg)\|(.*?)\}\}/ig, '{{$2}}' );
 
-			var templatesToRemove = [
+			const templatesToRemove = [
 				'AfC postpone G13',
 				'Draft topics',
 				'AfC topic',
@@ -553,7 +553,7 @@
 				'Promising draft'
 			];
 
-			templatesToRemove.forEach( function ( template ) {
+			templatesToRemove.forEach( ( template ) => {
 				text = text.replace( new RegExp( '\\{\\{' + template + '\\s*\\|?(.*?)\\}\\}\\n?', 'gi' ), '' );
 			} );
 
@@ -604,7 +604,7 @@
 		// Convert http://-style links to other wikipages to wikicode syntax
 		// FIXME: Break this out into its own core function? Will it be used elsewhere?
 		function convertExternalLinksToWikilinks( text ) {
-			var linkRegex = /\[{1,2}(?:https?:)?\/\/(?:en.wikipedia.org\/wiki|enwp.org)\/([^\s|\][]+)(?:\s|\|)?((?:\[\[[^[\]]*\]\]|[^\][])*)\]{1,2}/ig,
+			let linkRegex = /\[{1,2}(?:https?:)?\/\/(?:en.wikipedia.org\/wiki|enwp.org)\/([^\s|\][]+)(?:\s|\|)?((?:\[\[[^[\]]*\]\]|[^\][])*)\]{1,2}/ig,
 				linkMatch = linkRegex.exec( text ),
 				title, displayTitle, newLink;
 
@@ -685,14 +685,14 @@
 		// to delete its matches in a loop. If it were global, then
 		// it would internally keep track of lsatIndex - then given
 		// two adjacent categories, only the first would get deleted
-		var catIndex, match,
+		let catIndex, match,
 			text = this.text,
 			categoryRegex = /\[\[:?Category:.*?\s*\]\]/i,
 			newCategoryCode = '\n';
 
 		// Create the wikicode block
-		$.each( categories, function ( _, category ) {
-			var trimmed = $.trim( category );
+		$.each( categories, ( _, category ) => {
+			const trimmed = $.trim( category );
 			if ( trimmed ) {
 				newCategoryCode += '\n[[Category:' + trimmed + ']]';
 			}
@@ -721,8 +721,8 @@
 	};
 
 	AFCH.Text.prototype.updateShortDescription = function ( existingShortDescription, newShortDescription ) {
-		var shortDescTemplateExists = /\{\{[Ss]hort ?desc(ription)?\s*\|/.test( this.text );
-		var shortDescExists = !!existingShortDescription;
+		const shortDescTemplateExists = /\{\{[Ss]hort ?desc(ription)?\s*\|/.test( this.text );
+		const shortDescExists = !!existingShortDescription;
 
 		if ( newShortDescription ) {
 			// 1. No shortdesc - insert the one provided by user
@@ -772,7 +772,7 @@
 
 	// If AFCH is destroyed via AFCH.destroy(),
 	// remove the $afch window and the launch link
-	AFCH.addDestroyFunction( function () {
+	AFCH.addDestroyFunction( () => {
 		$afchLaunchLink.remove();
 
 		// The $afch window might not exist yet; make
@@ -799,7 +799,7 @@
 							.html( '&#x25c0; back to options' ) // back arrow
 							.attr( 'title', 'Go back' )
 							.addClass( 'hidden' )
-							.click( function () {
+							.on( 'click', () => {
 								// Reload the review panel
 								spinnerAndRun( setupReviewPanel );
 							} ),
@@ -808,7 +808,7 @@
 						$( '<div>' )
 							.addClass( 'close-link' )
 							.html( '&times;' )
-							.click( function () {
+							.on( 'click', () => {
 								// DIE DIE DIE (...then allow clicks on the launch link again)
 								$afch.remove();
 								$afchLaunchLink
@@ -842,18 +842,18 @@
 		setupReviewPanel();
 
 		// If the "Review" link is clicked again, just reload the main view
-		$afchLaunchLink.click( function () {
+		$afchLaunchLink.on( 'click', () => {
 			spinnerAndRun( setupReviewPanel );
 		} );
 	}
 
 	function setupReviewPanel() {
 		// Store this to a variable so we can wait for its success
-		var loadViews = $.ajax( {
+		const loadViews = $.ajax( {
 			type: 'GET',
 			url: AFCH.consts.baseurl + '/tpl-submissions.js',
 			dataType: 'text'
-		} ).done( function ( data ) {
+		} ).done( ( data ) => {
 			afchViews = new AFCH.Views( data );
 			afchViewer = new AFCH.Viewer( afchViews, $afchWrapper );
 		} );
@@ -869,8 +869,8 @@
 		$.when(
 			afchSubmission.parse(),
 			loadViews
-		).then( function ( submission ) {
-			var extrasRevealed = false;
+		).then( ( submission ) => {
+			let extrasRevealed = false;
 
 			// Render the base buttons view
 			loadView( 'main', {
@@ -884,16 +884,16 @@
 
 			// Set up the extra options slide-out panel, which appears
 			// when the user click on the chevron
-			$afch.find( '#afchExtra .open' ).click( function () {
-				var $extra = $afch.find( '#afchExtra' );
+			$afch.find( '#afchExtra .open' ).on( 'click', () => {
+				const $extra = $afch.find( '#afchExtra' );
 
 				if ( extrasRevealed ) {
 					$extra.find( 'a' ).hide();
-					$extra.stop().animate( { width: '20px' }, 100, 'swing', function () {
+					$extra.stop().animate( { width: '20px' }, 100, 'swing', () => {
 						extrasRevealed = false;
 					} );
 				} else {
-					$extra.stop().animate( { width: '210px' }, 150, 'swing', function () {
+					$extra.stop().animate( { width: '210px' }, 150, 'swing', () => {
 						$extra.find( 'a' ).css( 'display', 'block' );
 						extrasRevealed = true;
 					} );
@@ -904,27 +904,27 @@
 			AFCH.preferences.initLink( $afch.find( 'span.preferences-wrapper' ), 'preferences' );
 
 			// Set up click handlers
-			$afch.find( '#afchAccept' ).click( function () {
+			$afch.find( '#afchAccept' ).on( 'click', () => {
 				spinnerAndRun( showAcceptOptions );
 			} );
-			$afch.find( '#afchDecline' ).click( function () {
+			$afch.find( '#afchDecline' ).on( 'click', () => {
 				spinnerAndRun( showDeclineOptions );
 			} );
-			$afch.find( '#afchComment' ).click( function () {
+			$afch.find( '#afchComment' ).on( 'click', () => {
 				spinnerAndRun( showCommentOptions );
 			} );
-			$afch.find( '#afchSubmit' ).click( function () {
+			$afch.find( '#afchSubmit' ).on( 'click', () => {
 				spinnerAndRun( showSubmitOptions );
 			} );
-			$afch.find( '#afchClean' ).click( function () {
+			$afch.find( '#afchClean' ).on( 'click', () => {
 				handleCleanup();
 			} );
-			$afch.find( '#afchMark' ).click( function () {
+			$afch.find( '#afchMark' ).on( 'click', () => {
 				handleMark( /* unmark */ submission.isUnderReview );
 			} );
 
 			// Load warnings about the page, then slide them in
-			getSubmissionWarnings().done( function ( warnings ) {
+			getSubmissionWarnings().done( ( warnings ) => {
 				if ( warnings.length ) {
 					// FIXME: CSS-based slide-in animation instead to avoid having
 					// to use stupid hide() + removeClass() workaround?
@@ -937,12 +937,12 @@
 
 			// Get G13 eligibility and when known, display relevant buttons...
 			// but don't hold up the rest of the loading to do so
-			submission.isG13Eligible().done( function ( eligible ) {
+			submission.isG13Eligible().done( ( eligible ) => {
 				$afch.find( '.g13-related' ).toggleClass( 'hidden', !eligible );
-				$afch.find( '#afchG13' ).click( function () {
+				$afch.find( '#afchG13' ).on( 'click', () => {
 					handleG13();
 				} );
-				$afch.find( '#afchPostponeG13' ).click( function () {
+				$afch.find( '#afchPostponeG13' ).on( 'click', () => {
 					spinnerAndRun( showPostponeG13Options );
 				} );
 			} );
@@ -955,7 +955,7 @@
 	 * @return {jQuery}
 	 */
 	function getSubmissionWarnings() {
-		var deferred = $.Deferred(),
+		const deferred = $.Deferred(),
 			warnings = [];
 
 		/**
@@ -966,7 +966,7 @@
 		 * @param {Function|string} onAction function to call on success, or URL to browse to
 		 */
 		function addWarning( message, actionMessage, onAction ) {
-			var $action,
+			let $action,
 				$warning = $( '<div>' )
 					.addClass( 'afch-warning' )
 					.text( message );
@@ -978,7 +978,7 @@
 					.appendTo( $warning );
 
 				if ( typeof onAction === 'function' ) {
-					$action.click( onAction );
+					$action.on( 'click', onAction );
 				} else {
 					$action
 						.attr( 'target', '_blank' )
@@ -990,16 +990,13 @@
 		}
 
 		function checkReferences() {
-			var deferred = $.Deferred();
+			const deferred = $.Deferred();
 
-			afchPage.getText( false ).done( function ( text ) {
-				var refBeginRe = /<\s*ref.*?\s*>/ig,
-					refBeginMatches = $.grep( text.match( refBeginRe ) || [], function ( ref ) {
-						// If the ref is closed already, we don't want it
-						// (returning true keeps the item, false removes it)
-						return ref.indexOf( '/>', ref.length - 2 ) === -1;
-					} ),
-
+			afchPage.getText( false ).done( ( text ) => {
+				const refBeginRe = /<\s*ref.*?\s*>/ig,
+					// If the ref is closed already, we don't want it
+					// (returning true keeps the item, false removes it)
+					refBeginMatches = $.grep( text.match( refBeginRe ) || [], ( ref ) => ref.indexOf( '/>', ref.length - 2 ) === -1 ),
 					refEndRe = /<\/\s*ref\s*>/ig,
 					refEndMatches = text.match( refEndRe ) || [],
 
@@ -1019,13 +1016,13 @@
 				// <ref>1<ref> instead of <ref>1</ref> detection
 				if ( malformedRefs.length ) {
 					addWarning( 'The submission contains malformed <ref> tags.', 'View details', function () {
-						var $warningDiv = $( this ).parent();
-						var $malformedRefWrapper = $( '<div>' )
+						const $warningDiv = $( this ).parent();
+						const $malformedRefWrapper = $( '<div>' )
 							.addClass( 'malformed-refs' )
 							.appendTo( $warningDiv );
 
 						// Show the relevant code snippets
-						$.each( malformedRefs, function ( _, ref ) {
+						$.each( malformedRefs, ( _, ref ) => {
 							$( '<div>' )
 								.addClass( 'code-wrapper' )
 								.append( $( '<pre>' ).text( ref ) )
@@ -1058,7 +1055,7 @@
 		}
 
 		function checkDeletionLog() {
-			var deferred = $.Deferred();
+			const deferred = $.Deferred();
 
 			// Don't show deletion notices for "sandbox" to avoid useless
 			// information when reviewing user sandboxes and the like
@@ -1075,8 +1072,8 @@
 				letype: 'delete',
 				lelimit: 10,
 				letitle: afchSubmission.shortTitle
-			} ).done( function ( data ) {
-				var rawDeletions = data.query.logevents;
+			} ).done( ( data ) => {
+				const rawDeletions = data.query.logevents;
 
 				if ( !rawDeletions.length ) {
 					deferred.resolve();
@@ -1085,11 +1082,11 @@
 
 				addWarning( 'The page "' + afchSubmission.shortTitle + '" has been deleted ' + rawDeletions.length + ( rawDeletions.length === 10 ? '+' : '' ) +
 					' time' + ( rawDeletions.length > 1 ? 's' : '' ) + '.', 'View deletion log', function () {
-					var $toggleLink = $( this ).addClass( 'deletion-log-toggle' ),
+					const $toggleLink = $( this ).addClass( 'deletion-log-toggle' ),
 						$warningDiv = $toggleLink.parent(),
 						deletions = [];
 
-					$.each( rawDeletions, function ( _, deletion ) {
+					$.each( rawDeletions, ( _, deletion ) => {
 						deletions.push( {
 							timestamp: deletion.timestamp,
 							relativeTimestamp: AFCH.relativeTimeSince( deletion.timestamp ),
@@ -1117,7 +1114,7 @@
 		}
 
 		function checkReviewState() {
-			var reviewer, isOwnReview;
+			let reviewer, isOwnReview;
 
 			if ( afchSubmission.isUnderReview ) {
 				isOwnReview = afchSubmission.params.reviewer === AFCH.consts.user;
@@ -1132,17 +1129,17 @@
 					' began reviewing this submission ' + AFCH.relativeTimeSince( afchSubmission.params.reviewts ) :
 					' already began reviewing this submission' ) + '.',
 				isOwnReview ? 'Unmark as under review' : 'View page history',
-				isOwnReview ? function () {
+				isOwnReview ? () => {
 					handleMark( /* unmark */ true );
 				} : mw.util.getUrl( AFCH.consts.pagename, { action: 'history' } ) );
 			}
 		}
 
 		function checkLongComments() {
-			var deferred = $.Deferred();
+			const deferred = $.Deferred();
 
-			afchPage.getText( false ).done( function ( rawText ) {
-				var
+			afchPage.getText( false ).done( ( rawText ) => {
+				const
 					// Simulate cleanUp first so that we don't warn about HTML
 					// comments that the script will remove anyway in the future
 					text = ( new AFCH.Text( rawText ) ).cleanUp( true ),
@@ -1154,13 +1151,13 @@
 				if ( numberOfComments ) {
 					addWarning( 'The page contains ' + ( oneComment ? 'an' : '' ) + ' HTML comment' + ( oneComment ? '' : 's' ) +
 						' longer than 30 characters.', 'View comment' + ( oneComment ? '' : 's' ), function () {
-						var $warningDiv = $( this ).parent(),
+						const $warningDiv = $( this ).parent(),
 							$commentsWrapper = $( '<div>' )
 								.addClass( 'long-comments' )
 								.appendTo( $warningDiv );
 
 						// Show the relevant code snippets
-						$.each( longCommentMatches, function ( _, comment ) {
+						$.each( longCommentMatches, ( _, comment ) => {
 							$( '<div>' )
 								.addClass( 'code-wrapper' )
 								.append( $( '<pre>' ).text( $.trim( comment ) ) )
@@ -1185,8 +1182,8 @@
 			return AFCH.api.get( {
 				action: 'pagetriagelist',
 				page_id: mw.config.get( 'wgArticleId' )
-			} ).then( function ( json ) {
-				var triageInfo = json.pagetriagelist.pages[ 0 ];
+			} ).then( ( json ) => {
+				const triageInfo = json.pagetriagelist.pages[ 0 ];
 				if ( triageInfo && Number( triageInfo.copyvio ) === mw.config.get( 'wgCurRevisionId' ) ) {
 					addWarning(
 						'This submission may contain copyright violations',
@@ -1198,20 +1195,18 @@
 		}
 
 		function checkForBlocks() {
-			return afchSubmission.getSubmitter().then( function ( creator ) {
-				return checkIfUserIsBlocked( creator ).then( function ( blockData ) {
-					if ( blockData !== null ) {
-						var date = 'infinity';
-						if ( blockData.expiry !== 'infinity' ) {
-							var data = new Date( blockData.expiry );
-							var monthNames = [ 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December' ];
-							date = data.getUTCDate() + ' ' + monthNames[ data.getUTCMonth() ] + ' ' + data.getUTCFullYear() + ' ' + data.getUTCHours() + ':' + data.getUTCMinutes() + ' UTC';
-						}
-						var warning = 'Submitter ' + creator + ' was blocked by ' + blockData.by + ' with an expiry time of ' + date + '. Reason: ' + blockData.reason;
-						addWarning( warning );
+			return afchSubmission.getSubmitter().then( ( creator ) => checkIfUserIsBlocked( creator ).then( ( blockData ) => {
+				if ( blockData !== null ) {
+					let date = 'infinity';
+					if ( blockData.expiry !== 'infinity' ) {
+						const data = new Date( blockData.expiry );
+						const monthNames = [ 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December' ];
+						date = data.getUTCDate() + ' ' + monthNames[ data.getUTCMonth() ] + ' ' + data.getUTCFullYear() + ' ' + data.getUTCHours() + ':' + data.getUTCMinutes() + ' UTC';
 					}
-				} );
-			} );
+					const warning = 'Submitter ' + creator + ' was blocked by ' + blockData.by + ' with an expiry time of ' + date + '. Reason: ' + blockData.reason;
+					addWarning( warning );
+				}
+			} ) );
 		}
 
 		$.when(
@@ -1221,7 +1216,7 @@
 			checkLongComments(),
 			checkForCopyvio(),
 			checkForBlocks()
-		).then( function () {
+		).then( () => {
 			deferred.resolve( warnings );
 		} );
 
@@ -1232,7 +1227,7 @@
 	 * Stores useful strings to AFCH.msg
 	 */
 	function setMessages() {
-		var headerBegin = '== Your submission at [[Wikipedia:Articles for creation|Articles for creation]]: ';
+		const headerBegin = '== Your submission at [[Wikipedia:Articles for creation|Articles for creation]]: ';
 		AFCH.msg.set( {
 			// $1 = article name
 			// $2 = article class or '' if not available
@@ -1281,7 +1276,7 @@
 	 *                             applied to it
 	 */
 	function prepareForProcessing( actionTitle, actionClass ) {
-		var $content = $afch.find( '#afchContent' ),
+		let $content = $afch.find( '#afchContent' ),
 			$submitBtn = $content.find( '#afchSubmitForm' );
 
 		// If we can't find a submit button or a content area, load
@@ -1320,7 +1315,7 @@
 	 * auto-reloads the page.
 	 */
 	function setupAjaxStopHandler() {
-		$( document ).ajaxStop( function () {
+		$( document ).on( 'ajaxStop', () => {
 			$afch.find( '#afchSubmitForm' )
 				.text( 'Done' )
 				.append(
@@ -1341,7 +1336,7 @@
 			} );
 
 			// Also, automagically reload the page in place
-			$( '#mw-content-text' ).load( AFCH.consts.pagelink + ' #mw-content-text', function () {
+			$( '#mw-content-text' ).load( AFCH.consts.pagelink + ' #mw-content-text', () => {
 				$afch.find( '#reloadLink' ).text( '(reload)' );
 				// Fire the hook for new page content
 				mw.hook( 'wikipage.content' ).fire( $( '#mw-content-text' ) );
@@ -1365,11 +1360,11 @@
 	 *                           into the data passed to `fn`
 	 */
 	function addFormSubmitHandler( fn, extraData ) {
-		$afch.find( '#afchSubmitForm' ).click( function () {
-			var data = {};
+		$afch.find( '#afchSubmitForm' ).on( 'click', () => {
+			const data = {};
 
 			// Provide page text; use cache created after afchSubmission.parse()
-			afchPage.getText( false ).done( function ( text ) {
+			afchPage.getText( false ).done( ( text ) => {
 				data.afchText = new AFCH.Text( text );
 
 				// Also provide the values for each afch-input element
@@ -1378,7 +1373,7 @@
 				// Also provide extra data
 				$.extend( data, extraData );
 
-				checkForEditConflict().then( function ( editConflict ) {
+				checkForEditConflict().then( ( editConflict ) => {
 					if ( editConflict ) {
 						showEditConflictMessage();
 						return;
@@ -1401,7 +1396,7 @@
 	 * @param {Function} fn function to call when spinner has been displayed
 	 */
 	function spinnerAndRun( fn ) {
-		var $spinner, $container = $afch.find( '#afchContent' );
+		let $spinner, $container = $afch.find( '#afchContent' );
 
 		// Add a new spinner if one doesn't already exist
 		if ( !$container.find( '.mw-spinner' ).length ) {
@@ -1452,7 +1447,7 @@
 		 * @return {jQuery.Deferred}
 		 */
 		function loadWikiProjectList() {
-			var deferred = $.Deferred(),
+			let deferred = $.Deferred(),
 				// Left over from when a new version of AFCH would invalidate the WikiProject cache. The lsKey doesn't change nowadays though.
 				lsKey = 'mw-afch-wikiprojects-2',
 				wikiProjects = mw.storage.getObject( lsKey );
@@ -1464,8 +1459,8 @@
 				$.ajax( {
 					url: mw.config.get( 'wgServer' ) + '/w/index.php?title=Wikipedia:WikiProject_Articles_for_creation/WikiProject_templates.json&action=raw&ctype=text/json',
 					dataType: 'json'
-				} ).done( function ( projectData ) {
-					$.each( projectData, function ( display, template ) {
+				} ).done( ( projectData ) => {
+					$.each( projectData, ( display, template ) => {
 						wikiProjects.push( {
 							displayName: display,
 							templateName: template
@@ -1478,7 +1473,7 @@
 					}
 
 					deferred.resolve( wikiProjects );
-				} ).fail( function ( jqxhr, textStatus, errorThrown ) {
+				} ).fail( ( jqxhr, textStatus, errorThrown ) => {
 					console.error( 'Could not parse WikiProject list: ', textStatus, errorThrown );
 				} );
 			}
@@ -1486,17 +1481,15 @@
 			return deferred;
 		}
 
-		var existingWikiProjectsPromise = $.when(
+		const existingWikiProjectsPromise = $.when(
 			loadWikiProjectList(),
 			new AFCH.Page( 'Draft talk:' + afchSubmission.shortTitle ).getTemplates()
-		).then( function ( wikiProjects, templates ) {
-			var templateNames = templates.map( function ( template ) {
-				return template.target.trim().toLowerCase();
-			} );
+		).then( ( wikiProjects, templates ) => {
+			let templateNames = templates.map( ( template ) => template.target.trim().toLowerCase() );
 
 			// Turn the WikiProject list into an Object to make lookups faster
-			var wikiProjectMap = {};
-			for ( var projIdx = 0; projIdx < wikiProjects.length; projIdx++ ) {
+			let wikiProjectMap = {};
+			for ( let projIdx = 0; projIdx < wikiProjects.length; projIdx++ ) {
 				wikiProjectMap[ wikiProjects[ projIdx ].templateName.toLowerCase() ] = {
 					displayName: wikiProjects[ projIdx ].displayName,
 					templateName: wikiProjects[ projIdx ].templateName,
@@ -1504,7 +1497,7 @@
 				};
 			}
 
-			var alreadyHasWPBio = false;
+			let alreadyHasWPBio = false;
 
 			if ( templates.length === 0 ) {
 				return {
@@ -1513,8 +1506,8 @@
 				};
 			}
 
-			var otherTemplates = [];
-			for ( var tplIdx = 0; tplIdx < templateNames.length; tplIdx++ ) {
+			let otherTemplates = [];
+			for ( let tplIdx = 0; tplIdx < templateNames.length; tplIdx++ ) {
 				if ( wikiProjectMap.hasOwnProperty( templateNames[ tplIdx ] ) ) {
 					wikiProjectMap[ templateNames[ tplIdx ] ].alreadyOnPage = true;
 				} else if ( templateNames[ tplIdx ] === 'wikiproject biography' ) {
@@ -1526,22 +1519,20 @@
 
 			// If any templates weren't in the WikiProject map, check if they were redirects
 			if ( otherTemplates.length > 0 ) {
-				var titles = otherTemplates.map( function ( n ) {
-					return 'Template:' + n;
-				} );
+				let titles = otherTemplates.map( ( n ) => 'Template:' + n );
 				titles = titles.slice( 0, 50 ); // prevent API error by capping max # of titles at 50
 				titles = titles.join( '|' );
 				return AFCH.api.post( {
 					action: 'query',
 					titles: titles,
 					redirects: 'true'
-				} ).then( function ( data ) {
-					var existingWPBioTemplateName = null;
+				} ).then( ( data ) => {
+					let existingWPBioTemplateName = null;
 					if ( data.query && data.query.redirects && data.query.redirects.length > 0 ) {
-						var redirs = data.query.redirects;
-						for ( var redirIdx = 0; redirIdx < redirs.length; redirIdx++ ) {
-							var redir = redirs[ redirIdx ].to.slice( 'Template:'.length ).toLowerCase();
-							var originalName = redirs[ redirIdx ].from.slice( 'Template:'.length );
+						let redirs = data.query.redirects;
+						for ( let redirIdx = 0; redirIdx < redirs.length; redirIdx++ ) {
+							let redir = redirs[ redirIdx ].to.slice( 'Template:'.length ).toLowerCase();
+							let originalName = redirs[ redirIdx ].from.slice( 'Template:'.length );
 							if ( wikiProjectMap.hasOwnProperty( redir ) ) {
 								wikiProjectMap[ redir ].alreadyOnPage = true;
 								wikiProjectMap[ redir ].realTemplateName = originalName;
@@ -1570,23 +1561,21 @@
 			existingWikiProjectsPromise,
 			afchPage.getCategories( /* useApi */ false, /* includeCategoryLinks */ true ),
 			afchPage.getShortDescription()
-		).then( function ( pageText, existingWikiProjectsResult, categories, shortDescription ) {
-			var alreadyHasWPBio = existingWikiProjectsResult.alreadyHasWPBio,
+		).then( ( pageText, existingWikiProjectsResult, categories, shortDescription ) => {
+			const alreadyHasWPBio = existingWikiProjectsResult.alreadyHasWPBio,
 				wikiProjectMap = existingWikiProjectsResult.wikiProjectMap,
 				existingWPBioTemplateName = existingWikiProjectsResult.existingWPBioTemplateName;
-			var existingWikiProjects = []; // already on draft's talk page
-			$.each( wikiProjectMap, function ( lowercaseTemplateName, obj ) {
+			const existingWikiProjects = []; // already on draft's talk page
+			$.each( wikiProjectMap, ( lowercaseTemplateName, obj ) => {
 				if ( obj.alreadyOnPage ) {
 					existingWikiProjects.push( obj );
 				}
 			} );
-			var hasWikiProjects = Object.keys( wikiProjectMap ).length > 0;
+			const hasWikiProjects = Object.keys( wikiProjectMap ).length > 0;
 			if ( !hasWikiProjects ) {
 				mw.notify( 'Could not load WikiProject list!' );
 			}
-			var wikiProjectObjs = Object.keys( wikiProjectMap ).map( function ( key ) {
-				return wikiProjectMap[ key ];
-			} );
+			const wikiProjectObjs = Object.keys( wikiProjectMap ).map( ( key ) => wikiProjectMap[ key ] );
 
 			loadView( 'accept', {
 				newTitle: afchSubmission.shortTitle,
@@ -1597,7 +1586,7 @@
 				// Only offer to patrol the page if not already patrolled (in other words, if
 				// the "Mark as patrolled" link can be found in the DOM)
 				showPatrolOption: !!$afch.find( '.patrollink' ).length
-			}, function () {
+			}, () => {
 				$afch.find( '#newAssessment' ).chosen( {
 					allow_single_deselect: true,
 					disable_search: true,
@@ -1607,8 +1596,8 @@
 
 				// If draft is assessed as stub, show stub sorting
 				// interface using User:SD0001/StubSorter.js
-				$afch.find( '#newAssessment' ).change( function () {
-					var isClassStub = $( this ).val() === 'stub';
+				$afch.find( '#newAssessment' ).on( 'change', function () {
+					const isClassStub = $( this ).val() === 'stub';
 					$afch.find( '#stubSorterWrapper' ).toggleClass( 'hidden', !isClassStub );
 					if ( isClassStub ) {
 						if ( mw.config.get( 'wgDBname' ) !== 'enwiki' ) {
@@ -1618,13 +1607,13 @@
 
 						if ( $afch.find( '#stubSorterContainer' ).html() === '' ) {
 							mw.hook( 'StubSorter_activate' ).fire( $afch.find( '#stubSorterContainer' ) );
-							var promise = $.when();
-							var wasStubSorterActivated = $afch.find( '#stubSorterContainer' ).html() !== '';
+							let promise = $.when();
+							const wasStubSorterActivated = $afch.find( '#stubSorterContainer' ).html() !== '';
 							if ( !wasStubSorterActivated ) {
 								promise = mw.loader.getScript( 'https://en.wikipedia.org/w/index.php?title=User:SD0001/StubSorter.js&action=raw&ctype=text/javascript' );
 							}
 
-							promise.then( function () {
+							promise.then( () => {
 								if ( !wasStubSorterActivated ) {
 									mw.hook( 'StubSorter_activate' ).fire( $afch.find( '#stubSorterContainer' ) );
 								}
@@ -1649,8 +1638,8 @@
 				// Extend the chosen menu for new WikiProjects. We hackily show a
 				// "Click to manually add {{PROJECT}}" link -- sadly, jquery.chosen
 				// doesn't support this natively.
-				$afch.find( '#newWikiProjects_chzn input' ).keyup( function () {
-					var $chzn = $afch.find( '#newWikiProjects_chzn' ),
+				$afch.find( '#newWikiProjects_chzn input' ).on( 'keyup', function () {
+					const $chzn = $afch.find( '#newWikiProjects_chzn' ),
 						$input = $( this ),
 						newProject = $input.val(),
 						$noResults = $chzn.find( 'li.no-results' );
@@ -1663,8 +1652,8 @@
 							.append(
 								$( '<a>' )
 									.text( 'Click to manually add {{' + newProject + '}} to the page\'s WikiProject list.' )
-									.click( function () {
-										var $wikiprojects = $afch.find( '#newWikiProjects' );
+									.on( 'click', () => {
+										const $wikiprojects = $afch.find( '#newWikiProjects' );
 
 										$( '<option>' )
 											.attr( 'value', newProject )
@@ -1688,8 +1677,8 @@
 				// Since jquery.chosen doesn't natively support dynamic results,
 				// we sneakily inject some dynamic suggestions instead. Consider
 				// switching to something like Select2 to avoid this hackery...
-				$afch.find( '#newCategories_chosen input' ).keyup( function ( e ) {
-					var $input = $( this ),
+				$afch.find( '#newCategories_chosen input' ).on( 'keyup', function ( e ) {
+					const $input = $( this ),
 						prefix = $input.val(),
 						$categories = $afch.find( '#newCategories' );
 
@@ -1704,7 +1693,7 @@
 					$input.css( 'width', '100%' );
 					$input.parent().css( 'width', '100%' );
 
-					AFCH.api.getCategoriesByPrefix( prefix ).done( function ( categories ) {
+					AFCH.api.getCategoriesByPrefix( prefix ).done( ( categories ) => {
 
 						// Reset the text box width again
 						$input.css( 'width', '100%' );
@@ -1720,7 +1709,7 @@
 						$categories.children().not( ':selected' ).remove();
 
 						// Now, add the new suggestions
-						$.each( categories, function ( _, category ) {
+						$.each( categories, ( _, category ) => {
 							$( '<option>' )
 								.attr( 'value', category )
 								.text( category )
@@ -1738,7 +1727,7 @@
 				} );
 
 				// Show bio options if Biography option checked
-				$afch.find( '#isBiography' ).change( function () {
+				$afch.find( '#isBiography' ).on( 'change', function () {
 					$afch.find( '#bioOptionsWrapper' ).toggleClass( 'hidden', !this.checked );
 				} );
 				if ( alreadyHasWPBio ) {
@@ -1746,12 +1735,12 @@
 				}
 
 				function prefillBiographyDetails() {
-					var titleParts;
+					let titleParts;
 
 					// Prefill `LastName, FirstName` for Biography if the page title is two words
 					// after removing any trailing parentheticals (likely disambiguation), and
 					// therefore probably safe to asssume in a `FirstName LastName` format.
-					var title = afchSubmission.shortTitle.replace( / \([\s\S]*?\)$/g, '' );
+					const title = afchSubmission.shortTitle.replace( / \([\s\S]*?\)$/g, '' );
 					titleParts = title.split( ' ' );
 					if ( titleParts.length === 2 ) {
 						$afch.find( '#subjectName' ).val( titleParts[ 1 ] + ', ' + titleParts[ 0 ] );
@@ -1760,14 +1749,14 @@
 				prefillBiographyDetails();
 
 				// If subject is dead, show options for death details
-				$afch.find( '#lifeStatus' ).change( function () {
+				$afch.find( '#lifeStatus' ).on( 'change', function () {
 					$afch.find( '#deathWrapper' ).toggleClass( 'hidden', $( this ).val() !== 'dead' );
 				} );
 
 				// Show an error if the page title already exists in the mainspace,
 				// or if the title is create-protected and user is not an admin
-				$afch.find( '#newTitle' ).keyup( function () {
-					var page,
+				$afch.find( '#newTitle' ).on( 'keyup', function () {
+					let page,
 						linkToPage,
 						$field = $( this ),
 						$status = $afch.find( '#titleStatus' ),
@@ -1793,7 +1782,7 @@
 					AFCH.api.get( {
 						action: 'query',
 						titles: 'Talk:' + page.rawTitle
-					} ).done( function ( data ) {
+					} ).done( ( data ) => {
 						if ( !data.query.pages.hasOwnProperty( '-1' ) ) {
 							$status.html( 'The talk page for "' + linkToPage + '" exists.' );
 						}
@@ -1812,21 +1801,21 @@
 							inprop: 'protection',
 							titles: page.rawTitle
 						} )
-					).then( function ( rawBlacklist, rawInfo ) {
-						var errorHtml, buttonText;
+					).then( ( rawBlacklist, rawInfo ) => {
+						let errorHtml, buttonText;
 
 						// Get just the result, not the Promise object
-						var blacklistResult = rawBlacklist[ 0 ],
+						let blacklistResult = rawBlacklist[ 0 ],
 							infoResult = rawInfo[ 0 ];
 
-						var pageAlreadyExists = !infoResult.query.pages.hasOwnProperty( '-1' );
+						const pageAlreadyExists = !infoResult.query.pages.hasOwnProperty( '-1' );
 
-						var pages = infoResult && infoResult.query && infoResult.query.pages && infoResult.query.pages;
-						var firstPageInObject = Object.values( pages )[ 0 ];
-						var pageIsRedirect = firstPageInObject && ( 'redirect' in firstPageInObject );
+						const pages = infoResult && infoResult.query && infoResult.query.pages && infoResult.query.pages;
+						const firstPageInObject = Object.values( pages )[ 0 ];
+						const pageIsRedirect = firstPageInObject && ( 'redirect' in firstPageInObject );
 
 						if ( pageAlreadyExists && pageIsRedirect ) {
-							var linkToRedirect = AFCH.jQueryToHtml( AFCH.makeLinkElementToPage( page.rawTitle, null, null, true ) );
+							const linkToRedirect = AFCH.jQueryToHtml( AFCH.makeLinkElementToPage( page.rawTitle, null, null, true ) );
 							errorHtml = '<br />Whoops, the page "' + linkToRedirect + '" already exists and is a redirect. <span id="afch-redirect-notification">Do you want to tag it for speedy deletion so you can accept this draft later? <a id="afch-redirect-tag-speedy">Yes</a> / <a id="afch-redirect-abort">No</a></span>';
 							buttonText = 'The proposed title already exists';
 						} else if ( pageAlreadyExists ) {
@@ -1836,7 +1825,7 @@
 							// If the page doesn't exist but IS create-protected and the
 							// current reviewer is not an admin, also display an error
 							// FIXME: offer one-click request unprotection?
-							$.each( infoResult.query.pages[ '-1' ].protection, function ( _, entry ) {
+							$.each( infoResult.query.pages[ '-1' ].protection, ( _, entry ) => {
 								if ( entry.type === 'create' && entry.level === 'sysop' && $.inArray( 'sysop', mw.config.get( 'wgUserGroups' ) ) === -1 ) {
 									errorHtml = 'Darn it, "' + linkToPage + '" is create-protected. You will need to request unprotection before accepting.';
 									buttonText = 'The proposed title is create-protected';
@@ -1863,12 +1852,12 @@
 						$status.html( errorHtml );
 
 						// Add listener for the "Do you want to tag it for speedy deletion so you can accept this draft later?" "yes" link.
-						$( '#afch-redirect-tag-speedy' ).on( 'click', function () {
+						$( '#afch-redirect-tag-speedy' ).on( 'click', () => {
 							handleAcceptOverRedirect( page.rawTitle );
 						} );
 
 						// Add listener for the "Do you want to tag it for speedy deletion so you can accept this draft later?" "no" link.
-						$( '#afch-redirect-abort' ).on( 'click', function () {
+						$( '#afch-redirect-abort' ).on( 'click', () => {
 							$( '#afch-redirect-notification' ).hide();
 						} );
 
@@ -1895,15 +1884,15 @@
 	}
 
 	function showDeclineOptions() {
-		loadView( 'decline', {}, function () {
-			var $reasons, $commonSection, declineCounts,
+		loadView( 'decline', {}, () => {
+			let $reasons, $commonSection, declineCounts,
 				pristineState = $afch.find( '#declineInputWrapper' ).html();
 
 			// pos is either 1 or 2, based on whether the chosen reason that
 			// is triggering this update is first or second in the multi-select
 			// control
 			function updateTextfield( newPrompt, newPlaceholder, newValue, pos ) {
-				var wrapper = $afch.find( '#textfieldWrapper' + ( pos === 2 ? '2' : '' ) );
+				const wrapper = $afch.find( '#textfieldWrapper' + ( pos === 2 ? '2' : '' ) );
 
 				// Update label and placeholder
 				wrapper.find( 'label' ).text( newPrompt );
@@ -1923,14 +1912,10 @@
 			declineCounts = AFCH.userData.get( 'decline-counts', false );
 
 			if ( declineCounts ) {
-				var declineList = $.map( declineCounts, function ( _, key ) {
-					return key;
-				} );
+				const declineList = $.map( declineCounts, ( _, key ) => key );
 
 				// Sort list in descending order (most-used at beginning)
-				declineList.sort( function ( a, b ) {
-					return declineCounts[ b ] - declineCounts[ a ];
-				} );
+				declineList.sort( ( a, b ) => declineCounts[ b ] - declineCounts[ a ] );
 
 				$reasons = $afch.find( '#declineReason' );
 				$commonSection = $( '<optgroup>' )
@@ -1938,8 +1923,8 @@
 					.insertBefore( $reasons.find( 'optgroup' ).first() );
 
 				// Show the 5 most used options
-				$.each( declineList.splice( 0, 5 ), function ( _, rationale ) {
-					var $relevant = $reasons.find( 'option[value="' + rationale + '"]' );
+				$.each( declineList.splice( 0, 5 ), ( _, rationale ) => {
+					const $relevant = $reasons.find( 'option[value="' + rationale + '"]' );
 					$relevant.clone( true ).appendTo( $commonSection );
 				} );
 			}
@@ -1966,8 +1951,8 @@
 			$afch.find( '#rejectReason_chosen' ).css( 'width', '350px' );
 
 			// And now add the handlers for when a specific decline reason is selected
-			$afch.find( '#declineReason' ).change( function () {
-				var reason = $afch.find( '#declineReason' ).val(),
+			$afch.find( '#declineReason' ).on( 'change', () => {
+				const reason = $afch.find( '#declineReason' ).val(),
 					candidateDupeName = ( afchSubmission.shortTitle !== 'sandbox' ) ? afchSubmission.shortTitle : '',
 					prevDeclineComment = $afch.find( '#declineTextarea' ).val(),
 					declineHandlers = {
@@ -1975,8 +1960,8 @@
 							$afch.find( '#cvUrlWrapper' ).removeClass( 'hidden' );
 							$afch.add( '#csdWrapper' ).removeClass( 'hidden' );
 
-							$afch.find( '#cvUrlTextarea' ).keyup( function () {
-								var text = $( this ).val(),
+							$afch.find( '#cvUrlTextarea' ).on( 'keyup', function () {
+								let text = $( this ).val(),
 									numUrls = text ? text.split( '\n' ).length : 0,
 									submitButton = $afch.find( '#afchSubmitForm' );
 								if ( numUrls >= 1 && numUrls <= 3 ) {
@@ -1995,7 +1980,7 @@
 							} );
 
 							// Check if there's an OTRS notice
-							new AFCH.Page( 'Draft talk:' + afchSubmission.shortTitle ).getText( /* usecache */ false ).done( function ( text ) {
+							new AFCH.Page( 'Draft talk:' + afchSubmission.shortTitle ).getText( /* usecache */ false ).done( ( text ) => {
 								if ( /ConfirmationOTRS/.test( text ) ) {
 									$afch.find( '#declineInputWrapper' ).append(
 										$( '<div>' )
@@ -2059,7 +2044,7 @@
 							size: 'large',
 							type: 'block'
 						} ).css( 'padding', '20px' ) );
-					AFCH.getReason( reason ).done( function ( html ) {
+					AFCH.getReason( reason ).done( ( html ) => {
 						$( '#previewContainer' ).html( html );
 					} );
 				}
@@ -2068,27 +2053,27 @@
 				// option, and the submit form button
 				$afch.find( '#declineTextarea' ).add( '#notifyWrapper' ).add( '#afchSubmitForm' )
 					.toggleClass( 'hidden', !reason || !reason.length )
-					.on( 'keyup', mw.util.debounce( 500, function () {
+					.on( 'keyup', mw.util.debounce( 500, () => {
 						previewComment( $( '#declineTextarea' ), $( '#declineInputPreview' ) );
 					} ) );
 			} ); // End change handler for the decline reason select box
 
 			// And the the handlers for when a specific REJECT reason is selected
-			$afch.find( '#rejectReason' ).change( function () {
-				var reason = $afch.find( '#rejectReason' ).val();
+			$afch.find( '#rejectReason' ).on( 'change', () => {
+				const reason = $afch.find( '#rejectReason' ).val();
 
 				// If a reason has been specified, show the textarea, notify
 				// option, and the submit form button
 				$afch.find( '#rejectTextarea' ).add( '#notifyWrapper' ).add( '#afchSubmitForm' )
 					.toggleClass( 'hidden', !reason || !reason.length )
-					.on( 'keyup', mw.util.debounce( 500, function () {
+					.on( 'keyup', mw.util.debounce( 500, () => {
 						previewComment( $( '#rejectTextarea' ), $( '#rejectInputPreview' ) );
 					} ) );
 			} ); // End change handler for the reject reason select box
 
 			// Attach the preview event listener
-			$afch.find( '#previewTrigger' ).click( function () {
-				var reason = $afch.find( '#declineReason' ).val();
+			$afch.find( '#previewTrigger' ).on( 'click', function () {
+				const reason = $afch.find( '#declineReason' ).val();
 				if ( this.textContent == '(preview)' && reason ) {
 					$( '#previewContainer' )
 						.empty()
@@ -2096,7 +2081,7 @@
 							size: 'large',
 							type: 'block'
 						} ).css( 'padding', '20px' ) );
-					var reasonDeferreds = reason.map( AFCH.getReason );
+					const reasonDeferreds = reason.map( AFCH.getReason );
 					$.when.apply( $, reasonDeferreds ).then( function () {
 						$( '#previewContainer' )
 							.html( Array.prototype.slice.call( arguments )
@@ -2110,8 +2095,8 @@
 			} );
 
 			// Attach the decline vs reject radio button listener
-			$afch.find( 'input[type=radio][name=declineReject]' ).click( function () {
-				var declineOrReject = $afch.find( 'input[name=declineReject]:checked' ).val();
+			$afch.find( 'input[type=radio][name=declineReject]' ).on( 'click', () => {
+				const declineOrReject = $afch.find( 'input[name=declineReject]:checked' ).val();
 				$afch.find( '#declineReasonWrapper' ).toggleClass( 'hidden', declineOrReject === 'reject' );
 				$afch.find( '#rejectReasonWrapper' ).toggleClass( 'hidden', declineOrReject === 'decline' );
 				$afch.find( '#declineInputWrapper' ).toggleClass( 'hidden', declineOrReject === 'reject' );
@@ -2131,12 +2116,12 @@
 	}
 
 	function previewComment( $textarea, $previewArea ) {
-		var commentText = $textarea.val();
+		const commentText = $textarea.val();
 		if ( commentText ) {
 			AFCH.api.parse( '{{AfC comment|1=' + addSignature( commentText ) + '}}', {
 				pst: true,
 				title: mw.config.get( 'wgPageName' )
-			} ).then( function ( html ) {
+			} ).then( ( html ) => {
 				$previewArea.html( html );
 			} );
 		} else {
@@ -2149,12 +2134,12 @@
 			action: 'query',
 			list: 'blocks',
 			bkusers: userName
-		} ).then( function ( data ) {
-			var blocks = data.query.blocks;
-			var blockData = null;
-			var currentTime = new Date().toISOString();
+		} ).then( ( data ) => {
+			const blocks = data.query.blocks;
+			let blockData = null;
+			const currentTime = new Date().toISOString();
 
-			for ( var i = 0; i < blocks.length; i++ ) {
+			for ( let i = 0; i < blocks.length; i++ ) {
 				if ( blocks[ i ].expiry === 'infinity' || blocks[ i ].expiry > currentTime ) {
 					blockData = blocks[ i ];
 					break;
@@ -2162,7 +2147,7 @@
 			}
 
 			return blockData;
-		} ).catch( function ( err ) {
+		} ).catch( ( err ) => {
 			console.log( 'abort ' + err );
 			return null;
 		} );
@@ -2171,14 +2156,14 @@
 	function showCommentOptions() {
 		loadView( 'comment', {} );
 
-		var $submitButton = $( '#afchSubmitForm' );
+		const $submitButton = $( '#afchSubmitForm' );
 		$submitButton.hide();
 
-		$( '#commentText' ).on( 'keyup', mw.util.debounce( 500, function () {
+		$( '#commentText' ).on( 'keyup', mw.util.debounce( 500, () => {
 			previewComment( $( '#commentText' ), $( '#commentPreview' ) );
 
 			// Hide the submit button if there is no comment typed in
-			var comment = $( '#commentText' ).val();
+			const comment = $( '#commentText' ).val();
 			if ( comment.length > 0 ) {
 				$submitButton.show();
 			} else {
@@ -2190,11 +2175,11 @@
 	}
 
 	function showSubmitOptions() {
-		var customSubmitters = [];
+		const customSubmitters = [];
 
 		// Iterate over the submitters and add them to the custom submitters list,
 		// displayed in the "submit as" dropdown.
-		$.each( afchSubmission.submitters, function ( index, submitter ) {
+		$.each( afchSubmission.submitters, ( index, submitter ) => {
 			customSubmitters.push( {
 				name: submitter,
 				description: submitter + ( index === 0 ? ' (most recent submitter)' : ' (past submitter)' ),
@@ -2204,7 +2189,7 @@
 
 		loadView( 'submit', {
 			customSubmitters: customSubmitters
-		}, function () {
+		}, () => {
 
 			// Reset the status indicators for the username & errors
 			function resetStatus() {
@@ -2217,8 +2202,8 @@
 			}
 
 			// Show the other textbox when `other` is selected in the menu
-			$afch.find( '#submitType' ).change( function () {
-				var isOtherSelected = $afch.find( '#submitType' ).val() === 'other';
+			$afch.find( '#submitType' ).on( 'change', () => {
+				const isOtherSelected = $afch.find( '#submitType' ).val() === 'other';
 
 				if ( isOtherSelected ) {
 					$afch.find( '#submitterNameWrapper' ).removeClass( 'hidden' );
@@ -2230,8 +2215,8 @@
 				resetStatus();
 
 				// Show an error if there's no such user
-				$afch.find( '#submitterName' ).keyup( function () {
-					var field = $( this ),
+				$afch.find( '#submitterName' ).on( 'keyup', function () {
+					const field = $( this ),
 						status = $( '#submitterNameStatus' ),
 						submitButton = $afch.find( '#afchSubmitForm' ),
 						submitter = field.val();
@@ -2260,7 +2245,7 @@
 						action: 'query',
 						list: 'users',
 						ususers: submitter
-					} ).done( function ( data ) {
+					} ).done( ( data ) => {
 						if ( data.query.users[ 0 ].missing !== undefined ) {
 							field.addClass( 'bad-input' );
 							status.text( 'No user named "' + submitter + '".' );
@@ -2298,8 +2283,8 @@
 		} );
 
 		// Mark the draft as under review.
-		afchPage.getText( false ).then( function ( rawText ) {
-			var text = new AFCH.Text( rawText );
+		afchPage.getText( false ).then( ( rawText ) => {
+			const text = new AFCH.Text( rawText );
 			afchSubmission.setStatus( 'r', {
 				reviewer: AFCH.consts.user,
 				reviewts: '{{subst:REVISIONTIMESTAMP}}'
@@ -2315,13 +2300,13 @@
 	}
 
 	function handleAccept( data ) {
-		var newText = data.afchText;
+		let newText = data.afchText;
 
 		AFCH.actions.movePage( afchPage.rawTitle, data.newTitle,
 			'Publishing accepted [[Wikipedia:Articles for creation|Articles for creation]] submission',
 			{ movetalk: true } ) // Also move associated talk page if exists (e.g. `Draft_talk:`)
-			.done( function ( moveData ) {
-				var $patrolLink,
+			.done( ( moveData ) => {
+				let $patrolLink,
 					newPage = new AFCH.Page( moveData.to ),
 					talkPage = newPage.getTalkPage(),
 					recentPage = new AFCH.Page( 'Wikipedia:Articles for creation/recent' );
@@ -2330,7 +2315,7 @@
 				// -------
 
 				// get comments left by reviewers to put on talk page
-				var comments = [];
+				let comments = [];
 				if ( data.copyComments ) {
 					comments = newText.getAfcComments();
 				}
@@ -2346,7 +2331,7 @@
 
 				// Add biography details
 				if ( data.isBiography ) {
-					var deathYear = 'LIVING';
+					let deathYear = 'LIVING';
 					if ( data.lifeStatus === 'dead' ) {
 						deathYear = data.deathYear || 'MISSING';
 					} else if ( data.lifeStatus === 'unknown' ) {
@@ -2387,7 +2372,7 @@
 				// TALK PAGE
 				// ---------
 
-				talkPage.getText().done( function ( talkText ) {
+				talkPage.getText().done( ( talkText ) => {
 					talkText = AFCH.addTalkPageBanners(
 						talkText,
 						data.newAssessment,
@@ -2398,7 +2383,7 @@
 						data.subjectName
 					);
 
-					var summary = 'Placing WikiProject banners';
+					const summary = 'Placing WikiProject banners';
 
 					if ( comments && comments.length > 0 ) {
 						talkText = talkText.trim() + '\n\n== Comments left by AfC reviewers ==\n' + comments.join( '\n\n' );
@@ -2414,7 +2399,7 @@
 				// ----------------
 
 				if ( data.notifyUser ) {
-					afchSubmission.getSubmitter().done( function ( submitter ) {
+					afchSubmission.getSubmitter().done( ( submitter ) => {
 						AFCH.actions.notifyUser( submitter, {
 							message: AFCH.msg.get( 'accepted-submission',
 								{ $1: newPage, $2: data.newAssessment } ),
@@ -2427,8 +2412,8 @@
 				// ----------
 
 				$.when( recentPage.getText(), afchSubmission.getSubmitter() )
-					.then( function ( text, submitter ) {
-						var newRecentText = text,
+					.then( ( text, submitter ) => {
+						let newRecentText = text,
 							matches = text.match( /{{afc contrib.*?}}\s*/gi ),
 							newTemplate = '{{afc contrib|' + data.newAssessment + '|' + newPage + '|' + submitter + '}}\n';
 
@@ -2450,7 +2435,7 @@
 				// LOG TO USERSPACE
 				// ----------
 
-				afchSubmission.getSubmitter().done( function ( submitter ) {
+				afchSubmission.getSubmitter().done( ( submitter ) => {
 					AFCH.actions.logAfc( {
 						title: afchPage.rawTitle,
 						actionType: 'accept',
@@ -2461,7 +2446,7 @@
 	}
 
 	function handleDecline( data ) {
-		var declineCounts,
+		let declineCounts,
 			isDecline = data.declineRejectWrapper === 'decline', // true=decline, false=reject
 			text = data.afchText,
 			declineReason = data.declineReason[ 0 ],
@@ -2524,7 +2509,7 @@
 
 		// Copyright violations get {{db-g12}}'d as well
 		if ( declineReason === 'cv' || declineReason2 === 'cv' ) {
-			var cvUrls = data.cvUrlTextarea.split( '\n' ).slice( 0, 3 ),
+			let cvUrls = data.cvUrlTextarea.split( '\n' ).slice( 0, 3 ),
 				urlParam = '';
 
 			if ( data.csdSubmission ) {
@@ -2558,7 +2543,7 @@
 		text.cleanUp();
 
 		// Build edit summary
-		var editSummary = ( isDecline ? 'Declining' : 'Rejecting' ) + ' submission: ',
+		let editSummary = ( isDecline ? 'Declining' : 'Rejecting' ) + ' submission: ',
 			lengthLimit = declineReason2 ? 120 : 180;
 		if ( declineReason === 'reason' ) {
 
@@ -2591,21 +2576,21 @@
 		} );
 
 		if ( data.notifyUser ) {
-			afchSubmission.getSubmitter().done( function ( submitter ) {
-				var userTalk = new AFCH.Page( ( new mw.Title( submitter, 3 ) ).getPrefixedText() ),
+			afchSubmission.getSubmitter().done( ( submitter ) => {
+				const userTalk = new AFCH.Page( ( new mw.Title( submitter, 3 ) ).getPrefixedText() ),
 					shouldTeahouse = data.inviteToTeahouse ? $.Deferred() : false;
 
 				// Check categories on the page to ensure that if the user has already been
 				// invited to the Teahouse, we don't invite them again.
 				if ( data.inviteToTeahouse ) {
-					userTalk.getCategories( /* useApi */ true ).done( function ( categories ) {
-						var hasTeahouseCat = false,
+					userTalk.getCategories( /* useApi */ true ).done( ( categories ) => {
+						let hasTeahouseCat = false,
 							teahouseCategories = [
 								'Category:Wikipedians who have received a Teahouse invitation',
 								'Category:Wikipedians who have received a Teahouse invitation through AfC'
 							];
 
-						$.each( categories, function ( _, cat ) {
+						$.each( categories, ( _, cat ) => {
 							if ( teahouseCategories.indexOf( cat ) !== -1 ) {
 								hasTeahouseCat = true;
 								return false;
@@ -2616,8 +2601,8 @@
 					} );
 				}
 
-				$.when( shouldTeahouse ).then( function ( teahouse ) {
-					var message;
+				$.when( shouldTeahouse ).then( ( teahouse ) => {
+					let message;
 					if ( isDecline ) {
 						message = AFCH.msg.get( 'declined-submission', {
 							$1: AFCH.consts.pagename,
@@ -2656,7 +2641,7 @@
 		}
 
 		// Log AfC if enabled and CSD if necessary
-		afchSubmission.getSubmitter().done( function ( submitter ) {
+		afchSubmission.getSubmitter().done( ( submitter ) => {
 			AFCH.actions.logAfc( {
 				title: afchPage.rawTitle,
 				actionType: isDecline ? 'decline' : 'reject',
@@ -2684,10 +2669,10 @@
 			prop: 'revisions',
 			revids: mw.config.get( 'wgCurRevisionId' ),
 			formatversion: 2
-		} ).then( function ( data ) {
+		} ).then( ( data ) => {
 			// convert timestamp format from 2024-05-03T09:40:20Z to 1714729221
-			var currentRevisionTimestampTZ = data.query.pages[ 0 ].revisions[ 0 ].timestamp;
-			var currentRevisionSeconds = ( new Date( currentRevisionTimestampTZ ).getTime() ) / 1000;
+			const currentRevisionTimestampTZ = data.query.pages[ 0 ].revisions[ 0 ].timestamp;
+			let currentRevisionSeconds = ( new Date( currentRevisionTimestampTZ ).getTime() ) / 1000;
 
 			// add one second. we don't want the current revision to be in our list of revisions
 			currentRevisionSeconds++;
@@ -2701,8 +2686,8 @@
 				formatversion: 2,
 				rvstart: currentRevisionSeconds,
 				rvdir: 'newer'
-			} ).then( function ( data ) {
-				var revisionsSinceTimestamp = data.query.pages[ 0 ].revisions;
+			} ).then( ( data ) => {
+				const revisionsSinceTimestamp = data.query.pages[ 0 ].revisions;
 				if ( revisionsSinceTimestamp && revisionsSinceTimestamp.length > 0 ) {
 					return true;
 				}
@@ -2715,17 +2700,17 @@
 		$( '#afchSubmitForm' ).hide();
 
 		// Putting this here instead of in tpl-submissions.html to reduce code duplication
-		var editConflictHtml = 'Edit conflict! Your changes were not saved. Please check the <a id="afchHistoryLink" href="">page history</a>. To avoid overwriting the other person\'s edits, please refresh this page and start again.';
+		const editConflictHtml = 'Edit conflict! Your changes were not saved. Please check the <a id="afchHistoryLink" href="">page history</a>. To avoid overwriting the other person\'s edits, please refresh this page and start again.';
 		$( '#afchEditConflict' ).html( editConflictHtml );
 
-		var historyLink = new mw.Uri( mw.util.getUrl( mw.config.get( 'wgPageName' ), { action: 'history' } ) );
+		const historyLink = new mw.Uri( mw.util.getUrl( mw.config.get( 'wgPageName' ), { action: 'history' } ) );
 		$( '#afchHistoryLink' ).prop( 'href', historyLink );
 
 		$( '#afchEditConflict' ).show();
 	}
 
 	function handleComment( data ) {
-		var text = data.afchText;
+		const text = data.afchText;
 
 		afchSubmission.addNewComment( data.commentText );
 		text.updateAfcTemplates( afchSubmission.makeWikicode() );
@@ -2738,7 +2723,7 @@
 		} );
 
 		if ( data.notifyUser ) {
-			afchSubmission.getSubmitter().done( function ( submitter ) {
+			afchSubmission.getSubmitter().done( ( submitter ) => {
 				AFCH.actions.notifyUser( submitter, {
 					message: AFCH.msg.get( 'comment-on-submission',
 						{ $1: AFCH.consts.pagename } ),
@@ -2749,7 +2734,7 @@
 	}
 
 	function handleSubmit( data ) {
-		var text = data.afchText,
+		const text = data.afchText,
 			submitter = $.Deferred(),
 			submitType = data.submitType;
 
@@ -2758,7 +2743,7 @@
 		} else if ( submitType === 'self' ) {
 			submitter.resolve( AFCH.consts.user );
 		} else if ( submitType === 'creator' ) {
-			afchPage.getCreator().done( function ( user ) {
+			afchPage.getCreator().done( ( user ) => {
 				submitter.resolve( user );
 			} );
 		} else {
@@ -2766,7 +2751,7 @@
 			submitter.resolve( data.submitType );
 		}
 
-		submitter.done( function ( submitter ) {
+		submitter.done( ( submitter ) => {
 			afchSubmission.setStatus( '', { u: submitter } );
 
 			text.updateAfcTemplates( afchSubmission.makeWikicode() );
@@ -2784,8 +2769,8 @@
 	function handleCleanup() {
 		prepareForProcessing( 'Cleaning' );
 
-		afchPage.getText( false ).done( function ( rawText ) {
-			var text = new AFCH.Text( rawText );
+		afchPage.getText( false ).done( ( rawText ) => {
+			const text = new AFCH.Text( rawText );
 
 			// Even though we didn't modify them, still update the templates,
 			// because the order may have changed/been corrected
@@ -2802,12 +2787,12 @@
 	}
 
 	function handleMark( unmark ) {
-		var actionText = ( unmark ? 'Unmarking' : 'Marking' );
+		const actionText = ( unmark ? 'Unmarking' : 'Marking' );
 
 		prepareForProcessing( actionText, 'mark' );
 
-		afchPage.getText( false ).done( function ( rawText ) {
-			var text = new AFCH.Text( rawText );
+		afchPage.getText( false ).done( ( rawText ) => {
+			const text = new AFCH.Text( rawText );
 
 			if ( unmark ) {
 				afchSubmission.setStatus( '', { reviewer: false, reviewts: false } );
@@ -2831,7 +2816,7 @@
 	function handleG13() {
 		// We start getting the creator now (for notification later) because ajax is
 		// radical and handles simultaneous requests, but we don't let it delay tagging
-		var gotCreator = afchPage.getCreator();
+		const gotCreator = afchPage.getCreator();
 
 		// Update the display
 		prepareForProcessing( 'Requesting', 'g13' );
@@ -2840,8 +2825,8 @@
 		$.when(
 			afchPage.getText( false ),
 			afchPage.getLastModifiedDate()
-		).then( function ( rawText, lastModified ) {
-			var text = new AFCH.Text( rawText );
+		).then( ( rawText, lastModified ) => {
+			const text = new AFCH.Text( rawText );
 
 			// Add the deletion tag and clean up for good measure
 			text.prepend( '{{db-g13|ts=' + AFCH.dateToMwTimestamp( lastModified ) + '}}\n' );
@@ -2854,17 +2839,17 @@
 			} );
 
 			// Now notify the page creator as well as any and all previous submitters
-			$.when( gotCreator ).then( function ( creator ) {
-				var usersToNotify = [ creator ];
+			$.when( gotCreator ).then( ( creator ) => {
+				const usersToNotify = [ creator ];
 
-				$.each( afchSubmission.submitters, function ( _, submitter ) {
+				$.each( afchSubmission.submitters, ( _, submitter ) => {
 					// Don't notify the same user multiple times
 					if ( usersToNotify.indexOf( submitter ) === -1 ) {
 						usersToNotify.push( submitter );
 					}
 				} );
 
-				$.each( usersToNotify, function ( _, user ) {
+				$.each( usersToNotify, ( _, user ) => {
 					AFCH.actions.notifyUser( user, {
 						message: AFCH.msg.get( 'g13-submission',
 							{ $1: AFCH.consts.pagename } ),
@@ -2883,11 +2868,11 @@
 	}
 
 	function handlePostponeG13( data ) {
-		var postponeCode,
+		let postponeCode,
 			text = data.afchText,
 			rawText = text.get(),
 			postponeRegex = /\{\{AfC postpone G13\s*(?:\|\s*(\d*)\s*)?\}\}/ig;
-		var match = postponeRegex.exec( rawText );
+		const match = postponeRegex.exec( rawText );
 
 		// First add the postpone template
 		if ( match ) {

--- a/tests/scaffold.js
+++ b/tests/scaffold.js
@@ -32,14 +32,14 @@ mw.loader = {
 	}
 };
 
-var basePageHtml = fs.readFileSync( './tests/test-frame.html' ).toString();
+const basePageHtml = fs.readFileSync( './tests/test-frame.html' ).toString();
 
 requireScript = function ( name ) {
 	return require( './../src/' + name );
 };
 
 setPageTitle = function ( title ) {
-	mw.config.get.mockImplementation( function ( requested ) {
+	mw.config.get.mockImplementation( ( requested ) => {
 		if ( requested === 'wgPageName' ) {
 			return title;
 		} else if ( requested === 'wgNamespaceNumber' ) {

--- a/tests/test-core.js
+++ b/tests/test-core.js
@@ -12,125 +12,125 @@ resetToAFCApplicablePage();
 requireScript( 'modules/core.js' );
 
 // It's always good to start simple :)
-describe( 'AFCH', function () {
-	it( 'is an object', function () {
+describe( 'AFCH', () => {
+	it( 'is an object', () => {
 		expect( typeof AFCH ).toBe( 'object' );
 	} );
 } );
 
-describe( 'AFCH.Page', function () {
+describe( 'AFCH.Page', () => {
 	// FIXME...
 } );
 
-describe( 'AFCH.removeEmptySectionAtEnd', function () {
-	it( 'no headings', function () {
-		var wikicode = 'Test';
-		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+describe( 'AFCH.removeEmptySectionAtEnd', () => {
+	it( 'no headings', () => {
+		const wikicode = 'Test';
+		const output = AFCH.removeEmptySectionAtEnd( wikicode );
 		expect( output ).toBe( 'Test' );
 	} );
 
-	it( 'one heading with body text', function () {
-		var wikicode = 'Test\n\n==Test2==\nMore test text\n';
-		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+	it( 'one heading with body text', () => {
+		const wikicode = 'Test\n\n==Test2==\nMore test text\n';
+		const output = AFCH.removeEmptySectionAtEnd( wikicode );
 		expect( output ).toBe( 'Test\n\n==Test2==\nMore test text\n' );
 	} );
 
-	it( 'two headings with body text', function () {
-		var wikicode = 'Test\n\n==Test2==\nMore test text\n\n== Test 3 ==\nYour text here.\n';
-		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+	it( 'two headings with body text', () => {
+		const wikicode = 'Test\n\n==Test2==\nMore test text\n\n== Test 3 ==\nYour text here.\n';
+		const output = AFCH.removeEmptySectionAtEnd( wikicode );
 		expect( output ).toBe( 'Test\n\n==Test2==\nMore test text\n\n== Test 3 ==\nYour text here.\n' );
 	} );
 
-	it( 'two headings with body text and with categories', function () {
-		var wikicode = 'Test\n\n==Test2==\nMore test text\n\n== Test 3 ==\nYour text here.\n[[Category:Test]]\n';
-		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+	it( 'two headings with body text and with categories', () => {
+		const wikicode = 'Test\n\n==Test2==\nMore test text\n\n== Test 3 ==\nYour text here.\n[[Category:Test]]\n';
+		const output = AFCH.removeEmptySectionAtEnd( wikicode );
 		expect( output ).toBe( 'Test\n\n==Test2==\nMore test text\n\n== Test 3 ==\nYour text here.\n[[Category:Test]]\n' );
 	} );
 
-	it( '1 heading, 1 category, 1 heading, 1 empty heading', function () {
-		var wikicode = 'Test\n\n==Test2==\nMore test text\n\n[[Category:Test]]\n\n== Test 3 ==\nYour text here.\n\n== Test 4 ==\n';
-		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+	it( '1 heading, 1 category, 1 heading, 1 empty heading', () => {
+		const wikicode = 'Test\n\n==Test2==\nMore test text\n\n[[Category:Test]]\n\n== Test 3 ==\nYour text here.\n\n== Test 4 ==\n';
+		const output = AFCH.removeEmptySectionAtEnd( wikicode );
 		expect( output ).toBe( 'Test\n\n==Test2==\nMore test text\n\n[[Category:Test]]\n\n== Test 3 ==\nYour text here.\n' );
 	} );
 
-	it( '1 heading, 2 categories, 1 heading, 1 empty heading', function () {
-		var wikicode = 'Test\n\n==Test2==\nMore test text\n\n[[Category:Test]]\n[[Category:Test2]]\n\n== Test 3 ==\nYour text here.\n\n== Test 4 ==\n';
-		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+	it( '1 heading, 2 categories, 1 heading, 1 empty heading', () => {
+		const wikicode = 'Test\n\n==Test2==\nMore test text\n\n[[Category:Test]]\n[[Category:Test2]]\n\n== Test 3 ==\nYour text here.\n\n== Test 4 ==\n';
+		const output = AFCH.removeEmptySectionAtEnd( wikicode );
 		expect( output ).toBe( 'Test\n\n==Test2==\nMore test text\n\n[[Category:Test]]\n[[Category:Test2]]\n\n== Test 3 ==\nYour text here.\n' );
 	} );
 
-	it( '1 empty heading, 2 categories, 1 heading, 1 empty heading', function () {
-		var wikicode = 'Test\n\n==Test2==\n[[Category:Test]]\n[[Category:Test2]]\n\n== Test 3 ==\nYour text here.\n\n== Test 4 ==\n';
-		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+	it( '1 empty heading, 2 categories, 1 heading, 1 empty heading', () => {
+		const wikicode = 'Test\n\n==Test2==\n[[Category:Test]]\n[[Category:Test2]]\n\n== Test 3 ==\nYour text here.\n\n== Test 4 ==\n';
+		const output = AFCH.removeEmptySectionAtEnd( wikicode );
 		expect( output ).toBe( 'Test\n\n==Test2==\n[[Category:Test]]\n[[Category:Test2]]\n\n== Test 3 ==\nYour text here.\n' );
 	} );
 
-	it( 'one heading without body text', function () {
-		var wikicode = 'Test\n\n==Test2==\n';
-		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+	it( 'one heading without body text', () => {
+		const wikicode = 'Test\n\n==Test2==\n';
+		const output = AFCH.removeEmptySectionAtEnd( wikicode );
 		expect( output ).toBe( 'Test\n' );
 	} );
 
-	it( 'two headings without body text', function () {
-		var wikicode = 'Test\n\n==Test2==\n\n== Test 3 ==\n';
-		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+	it( 'two headings without body text', () => {
+		const wikicode = 'Test\n\n==Test2==\n\n== Test 3 ==\n';
+		const output = AFCH.removeEmptySectionAtEnd( wikicode );
 		expect( output ).toBe( 'Test\n\n==Test2==\n' );
 	} );
 
-	it( 'two headings without body text and with one category', function () {
-		var wikicode = 'Test\n\n==Test2==\n\n== Test 3 ==\n\n[[Category:Test]]\n';
-		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+	it( 'two headings without body text and with one category', () => {
+		const wikicode = 'Test\n\n==Test2==\n\n== Test 3 ==\n\n[[Category:Test]]\n';
+		const output = AFCH.removeEmptySectionAtEnd( wikicode );
 		expect( output ).toBe( 'Test\n\n==Test2==\n\n[[Category:Test]]\n' );
 	} );
 
-	it( 'disabled category', function () {
-		var wikicode = 'Test\n\n==Test2==\n\n== Test 3 ==\n\n[[:Category:Test]]\n';
-		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+	it( 'disabled category', () => {
+		const wikicode = 'Test\n\n==Test2==\n\n== Test 3 ==\n\n[[:Category:Test]]\n';
+		const output = AFCH.removeEmptySectionAtEnd( wikicode );
 		expect( output ).toBe( 'Test\n\n==Test2==\n\n[[:Category:Test]]\n' );
 	} );
 
-	it( 'two headings without body text and with two categories #1', function () {
-		var wikicode = 'Test\n\n==Test2==\n\n== Test 3 ==\n\n[[Category:Test]]\n[[Category:Test2]]\n';
-		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+	it( 'two headings without body text and with two categories #1', () => {
+		const wikicode = 'Test\n\n==Test2==\n\n== Test 3 ==\n\n[[Category:Test]]\n[[Category:Test2]]\n';
+		const output = AFCH.removeEmptySectionAtEnd( wikicode );
 		expect( output ).toBe( 'Test\n\n==Test2==\n\n[[Category:Test]]\n[[Category:Test2]]\n' );
 	} );
 
-	it( 'two headings without body text and with two categories #2', function () {
-		var wikicode = 'Test\n\n==Test2==\n\n== Test 3 ==\n\n[[Category:Test]]\n\n[[Category:Test2]]\n';
-		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+	it( 'two headings without body text and with two categories #2', () => {
+		const wikicode = 'Test\n\n==Test2==\n\n== Test 3 ==\n\n[[Category:Test]]\n\n[[Category:Test2]]\n';
+		const output = AFCH.removeEmptySectionAtEnd( wikicode );
 		expect( output ).toBe( 'Test\n\n==Test2==\n\n[[Category:Test]]\n\n[[Category:Test2]]\n' );
 	} );
 
-	it( 'two headings without body text and with two categories #3', function () {
-		var wikicode = 'Test\n\n==Test2==\n\n== Test 3 ==\n\n[[Category:Test]]\n\n [[Category:Test2]]\n';
-		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+	it( 'two headings without body text and with two categories #3', () => {
+		const wikicode = 'Test\n\n==Test2==\n\n== Test 3 ==\n\n[[Category:Test]]\n\n [[Category:Test2]]\n';
+		const output = AFCH.removeEmptySectionAtEnd( wikicode );
 		expect( output ).toBe( 'Test\n\n==Test2==\n\n[[Category:Test]]\n\n [[Category:Test2]]\n' );
 	} );
 
-	it( 'don\'t trim if no heading was deleted', function () {
-		var wikicode = 'Test\n\n';
-		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+	it( 'don\'t trim if no heading was deleted', () => {
+		const wikicode = 'Test\n\n';
+		const output = AFCH.removeEmptySectionAtEnd( wikicode );
 		expect( output ).toBe( 'Test\n\n' );
 	} );
 
 	// Catastrophic backtracking occurs if this test causes the test suite to get stuck for a long time
-	it( 'should not cause regex catastrophic backtracking', function () {
-		var wikicode = '{{AFC submission}}\n==A==\n                                                                                                             \nB';
-		var output = AFCH.removeEmptySectionAtEnd( wikicode );
+	it( 'should not cause regex catastrophic backtracking', () => {
+		const wikicode = '{{AFC submission}}\n==A==\n                                                                                                             \nB';
+		const output = AFCH.removeEmptySectionAtEnd( wikicode );
 		expect( output ).toBe( '{{AFC submission}}\n==A==\n                                                                                                             \nB' );
 	} );
 } );
 
-describe( 'AFCH.addTalkPageBanners', function () {
-	it( 'talk page is blank', function () {
-		var wikicode = '';
-		var newAssessment = '';
-		var revId = 592485;
-		var isBiography = false;
-		var newWikiProjects = [];
-		var lifeStatus = 'unknown';
-		var subjectName = '';
-		var output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
+describe( 'AFCH.addTalkPageBanners', () => {
+	it( 'talk page is blank', () => {
+		const wikicode = '';
+		const newAssessment = '';
+		const revId = 592485;
+		const isBiography = false;
+		const newWikiProjects = [];
+		const lifeStatus = 'unknown';
+		const subjectName = '';
+		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
 `{{WikiProject banner shell|1=
 {{subst:WPAFC/article|oldid=592485}}
@@ -138,17 +138,17 @@ describe( 'AFCH.addTalkPageBanners', function () {
 		);
 	} );
 
-	it( 'talk page has existing sections', function () {
-		var wikicode =
+	it( 'talk page has existing sections', () => {
+		const wikicode =
 `== Hello ==
 I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="color:blue">'''Novem Linguae'''</span>]] <small>([[User talk:Novem Linguae|talk]])</small> 20:22, 10 April 2024 (UTC)`;
-		var newAssessment = '';
-		var revId = 592485;
-		var isBiography = false;
-		var newWikiProjects = [];
-		var lifeStatus = 'unknown';
-		var subjectName = '';
-		var output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
+		const newAssessment = '';
+		const revId = 592485;
+		const isBiography = false;
+		const newWikiProjects = [];
+		const lifeStatus = 'unknown';
+		const subjectName = '';
+		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
 `{{WikiProject banner shell|1=
 {{subst:WPAFC/article|oldid=592485}}
@@ -159,18 +159,18 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		);
 	} );
 
-	it( 'talk page has existing templates, WikiProject banners on top', function () {
-		var wikicode =
+	it( 'talk page has existing templates, WikiProject banners on top', () => {
+		const wikicode =
 `{{WikiProject Women}}
 {{translated page|ar|بحيرة كناو|version=|small=no|insertversion=|section=}}
 `;
-		var newAssessment = '';
-		var revId = 592485;
-		var isBiography = false;
-		var newWikiProjects = [];
-		var lifeStatus = 'unknown';
-		var subjectName = '';
-		var output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
+		const newAssessment = '';
+		const revId = 592485;
+		const isBiography = false;
+		const newWikiProjects = [];
+		const lifeStatus = 'unknown';
+		const subjectName = '';
+		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
 `{{WikiProject banner shell|1=
 {{subst:WPAFC/article|oldid=592485}}
@@ -180,18 +180,18 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		);
 	} );
 
-	it( 'talk page has existing templates, WikiProject banners on bottom', function () {
-		var wikicode =
+	it( 'talk page has existing templates, WikiProject banners on bottom', () => {
+		const wikicode =
 `{{translated page|ar|بحيرة كناو|version=|small=no|insertversion=|section=}}
 {{WikiProject Women}}
 `;
-		var newAssessment = '';
-		var revId = 592485;
-		var isBiography = false;
-		var newWikiProjects = [];
-		var lifeStatus = 'unknown';
-		var subjectName = '';
-		var output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
+		const newAssessment = '';
+		const revId = 592485;
+		const isBiography = false;
+		const newWikiProjects = [];
+		const lifeStatus = 'unknown';
+		const subjectName = '';
+		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
 `{{WikiProject banner shell|1=
 {{subst:WPAFC/article|oldid=592485}}
@@ -201,16 +201,16 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		);
 	} );
 
-	it( '|class= is removed from existing banners', function () {
-		var wikicode =
+	it( '|class= is removed from existing banners', () => {
+		const wikicode =
 `{{WikiProject Women|class=B}}`;
-		var newAssessment = '';
-		var revId = 592485;
-		var isBiography = false;
-		var newWikiProjects = [];
-		var lifeStatus = 'unknown';
-		var subjectName = '';
-		var output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
+		const newAssessment = '';
+		const revId = 592485;
+		const isBiography = false;
+		const newWikiProjects = [];
+		const lifeStatus = 'unknown';
+		const subjectName = '';
+		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
 `{{WikiProject banner shell|1=
 {{subst:WPAFC/article|oldid=592485}}
@@ -219,18 +219,18 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		);
 	} );
 
-	it( 'talk page has existing WikiProject banners', function () {
-		var wikicode =
+	it( 'talk page has existing WikiProject banners', () => {
+		const wikicode =
 `{{WikiProject Women}}
 {{WikiProject Women's sport}}
 {{WikiProject Somalia}}`;
-		var newAssessment = '';
-		var revId = 592507;
-		var isBiography = false;
-		var newWikiProjects = [ 'WikiProject Somalia', 'WikiProject Women', 'WikiProject Women\'s sport' ];
-		var lifeStatus = 'unknown';
-		var subjectName = '';
-		var output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
+		const newAssessment = '';
+		const revId = 592507;
+		const isBiography = false;
+		const newWikiProjects = [ 'WikiProject Somalia', 'WikiProject Women', 'WikiProject Women\'s sport' ];
+		const lifeStatus = 'unknown';
+		const subjectName = '';
+		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
 `{{WikiProject banner shell|1=
 {{subst:WPAFC/article|oldid=592507}}
@@ -241,20 +241,20 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		);
 	} );
 
-	it( 'talk page has existing WikiProject banner shell and banners', function () {
-		var wikicode =
+	it( 'talk page has existing WikiProject banner shell and banners', () => {
+		const wikicode =
 `{{WikiProject banner shell|
 {{WikiProject Women}}
 {{WikiProject Women's sport}}
 {{WikiProject Somalia}}
 }}`;
-		var newAssessment = '';
-		var revId = 592507;
-		var isBiography = false;
-		var newWikiProjects = [ 'WikiProject Somalia', 'WikiProject Women', 'WikiProject Women\'s sport' ];
-		var lifeStatus = 'unknown';
-		var subjectName = '';
-		var output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
+		const newAssessment = '';
+		const revId = 592507;
+		const isBiography = false;
+		const newWikiProjects = [ 'WikiProject Somalia', 'WikiProject Women', 'WikiProject Women\'s sport' ];
+		const lifeStatus = 'unknown';
+		const subjectName = '';
+		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
 `{{WikiProject banner shell|1=
 {{subst:WPAFC/article|oldid=592507}}
@@ -265,21 +265,21 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		);
 	} );
 
-	it( 'talk page has existing WikiProject banner shell and banners, and reviewer adds more banners', function () {
-		var wikicode =
+	it( 'talk page has existing WikiProject banner shell and banners, and reviewer adds more banners', () => {
+		const wikicode =
 `{{WikiProject banner shell|
 {{WikiProject Film}}
 {{WikiProject Biography}}
 {{WikiProject Women}}
 {{WikiProject Television}}
 }}`;
-		var newAssessment = '';
-		var revId = 592507;
-		var isBiography = true;
-		var newWikiProjects = [ 'WikiProject Romania' ];
-		var lifeStatus = 'living';
-		var subjectName = 'Lazarut, Raluca';
-		var output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
+		const newAssessment = '';
+		const revId = 592507;
+		const isBiography = true;
+		const newWikiProjects = [ 'WikiProject Romania' ];
+		const lifeStatus = 'living';
+		const subjectName = 'Lazarut, Raluca';
+		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
 `{{WikiProject banner shell|1=
 {{subst:WPAFC/article|oldid=592507}}
@@ -293,19 +293,19 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 	} );
 
 	// FIXME
-	it.skip( 'remove an existing WikiProject', function () {
-		var wikicode =
+	it.skip( 'remove an existing WikiProject', () => {
+		const wikicode =
 `{{WikiProject Women}}
 {{WikiProject Women's sport}}
 {{WikiProject Somalia}}`;
-		var newAssessment = '';
-		var revId = 592507;
-		var isBiography = false;
+		const newAssessment = '';
+		const revId = 592507;
+		const isBiography = false;
 		// user de-selected WikiProject Somalia
-		var newWikiProjects = [ 'WikiProject Women', 'WikiProject Women\'s sport' ];
-		var lifeStatus = 'unknown';
-		var subjectName = '';
-		var output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
+		const newWikiProjects = [ 'WikiProject Women', 'WikiProject Women\'s sport' ];
+		const lifeStatus = 'unknown';
+		const subjectName = '';
+		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
 `{{WikiProject banner shell|1=
 {{subst:WPAFC/article|oldid=592507}}
@@ -316,15 +316,15 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		);
 	} );
 
-	it( 'accept form is a biography with all fields filled in', function () {
-		var wikicode = '';
-		var newAssessment = 'B';
-		var revId = 592496;
-		var isBiography = true;
-		var newWikiProjects = [ 'WikiProject Africa', 'WikiProject Alabama' ];
-		var lifeStatus = 'living';
-		var subjectName = 'Jones, Bob';
-		var output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
+	it( 'accept form is a biography with all fields filled in', () => {
+		const wikicode = '';
+		const newAssessment = 'B';
+		const revId = 592496;
+		const isBiography = true;
+		const newWikiProjects = [ 'WikiProject Africa', 'WikiProject Alabama' ];
+		const lifeStatus = 'living';
+		const subjectName = 'Jones, Bob';
+		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
 `{{WikiProject banner shell|class=B|1=
 {{subst:WPAFC/article|oldid=592496}}
@@ -335,15 +335,15 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		);
 	} );
 
-	it( 'lifeStatus = dead', function () {
-		var wikicode = '';
-		var newAssessment = '';
-		var revId = 592496;
-		var isBiography = true;
-		var newWikiProjects = [];
-		var lifeStatus = 'dead';
-		var subjectName = '';
-		var output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
+	it( 'lifeStatus = dead', () => {
+		const wikicode = '';
+		const newAssessment = '';
+		const revId = 592496;
+		const isBiography = true;
+		const newWikiProjects = [];
+		const lifeStatus = 'dead';
+		const subjectName = '';
+		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
 `{{WikiProject banner shell|1=
 {{subst:WPAFC/article|oldid=592496}}
@@ -352,18 +352,18 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		);
 	} );
 
-	it.skip( 'talk page has {{wikiproject biography}}, and user selects that it\'s not a biography, so should remove {{wikiproject biography}}', function () {
-		var wikicode =
+	it.skip( 'talk page has {{wikiproject biography}}, and user selects that it\'s not a biography, so should remove {{wikiproject biography}}', () => {
+		const wikicode =
 `{{wikiproject biography|living=yes|class=B|listas=Jones, Bob}}
 {{WikiProject Somalia}}`;
-		var newAssessment = '';
-		var revId = 592496;
-		var isBiography = false;
+		const newAssessment = '';
+		const revId = 592496;
+		const isBiography = false;
 		// FIXME: if isBiography = false, WikiProject Biography should not be making it into this array
-		var newWikiProjects = [ 'WikiProject Biography', 'WikiProject Somalia' ];
-		var lifeStatus = 'unknown';
-		var subjectName = '';
-		var output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
+		const newWikiProjects = [ 'WikiProject Biography', 'WikiProject Somalia' ];
+		const lifeStatus = 'unknown';
+		const subjectName = '';
+		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
 `{{WikiProject banner shell|1=
 {{subst:WPAFC/article|oldid=592496}}
@@ -372,15 +372,15 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		);
 	} );
 
-	it( 'user selects class = disambiguation', function () {
-		var wikicode = '';
-		var newAssessment = 'disambig';
-		var revId = 592681;
-		var isBiography = false;
-		var newWikiProjects = [];
-		var lifeStatus = 'unknown';
-		var subjectName = '';
-		var output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
+	it( 'user selects class = disambiguation', () => {
+		const wikicode = '';
+		const newAssessment = 'disambig';
+		const revId = 592681;
+		const isBiography = false;
+		const newWikiProjects = [];
+		const lifeStatus = 'unknown';
+		const subjectName = '';
+		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
 `{{WikiProject banner shell|class=disambig|1=
 {{subst:WPAFC/article|oldid=592681}}
@@ -389,16 +389,16 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		);
 	} );
 
-	it( 'has {{OKA}} banner and puts it in the banner shell', function () {
-		var wikicode =
+	it( 'has {{OKA}} banner and puts it in the banner shell', () => {
+		const wikicode =
 `{{translated page|pl|Katowice Załęże|version=|small=no|insertversion=|section=}}{{OKA}}`;
-		var newAssessment = '';
-		var revId = 592681;
-		var isBiography = false;
-		var newWikiProjects = [];
-		var lifeStatus = 'unknown';
-		var subjectName = '';
-		var output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
+		const newAssessment = '';
+		const revId = 592681;
+		const isBiography = false;
+		const newWikiProjects = [];
+		const lifeStatus = 'unknown';
+		const subjectName = '';
+		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
 `{{WikiProject banner shell|1=
 {{subst:WPAFC/article|oldid=592681}}
@@ -409,46 +409,46 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 	} );
 } );
 
-describe( 'AFCH.removeDuplicateBanners', function () {
-	it( 'should handle empty array', function () {
-		var banners = [];
-		var output = AFCH.removeDuplicateBanners( banners );
+describe( 'AFCH.removeDuplicateBanners', () => {
+	it( 'should handle empty array', () => {
+		const banners = [];
+		const output = AFCH.removeDuplicateBanners( banners );
 		expect( output ).toEqual( [] );
 	} );
 
-	it( 'should handle array with 1 element', function () {
-		var banners = [ '{{Test}}' ];
-		var output = AFCH.removeDuplicateBanners( banners );
+	it( 'should handle array with 1 element', () => {
+		const banners = [ '{{Test}}' ];
+		const output = AFCH.removeDuplicateBanners( banners );
 		expect( output ).toEqual( [ '{{Test}}' ] );
 	} );
 
-	it( 'should handle array with 2 identical elements', function () {
-		var banners = [ '{{Test}}', '{{Test}}' ];
-		var output = AFCH.removeDuplicateBanners( banners );
+	it( 'should handle array with 2 identical elements', () => {
+		const banners = [ '{{Test}}', '{{Test}}' ];
+		const output = AFCH.removeDuplicateBanners( banners );
 		expect( output ).toEqual( [ '{{Test}}' ] );
 	} );
 
-	it( 'should handle array with 2 identical elements, case insensitive', function () {
-		var banners = [ '{{Test}}', '{{test}}' ];
-		var output = AFCH.removeDuplicateBanners( banners );
+	it( 'should handle array with 2 identical elements, case insensitive', () => {
+		const banners = [ '{{Test}}', '{{test}}' ];
+		const output = AFCH.removeDuplicateBanners( banners );
 		expect( output ).toEqual( [ '{{Test}}' ] );
 	} );
 
-	it( 'should handle array with 2 identical templates, but different parameters', function () {
-		var banners = [ '{{Test|1=a}}', '{{Test|2=b}}' ];
-		var output = AFCH.removeDuplicateBanners( banners );
+	it( 'should handle array with 2 identical templates, but different parameters', () => {
+		const banners = [ '{{Test|1=a}}', '{{Test|2=b}}' ];
+		const output = AFCH.removeDuplicateBanners( banners );
 		expect( output ).toEqual( [ '{{Test|1=a}}' ] );
 	} );
 
-	it( 'should handle a realistic example using WikiProject banners', function () {
-		var banners = [
+	it( 'should handle a realistic example using WikiProject banners', () => {
+		const banners = [
 			'{{WikiProject Australia}}',
 			'{{WikiProject Australia}}',
 			'{{wikiproject australia}}',
 			'{{WikiProject Australia|class=A}}',
 			'{{WikiProject Ontario}}'
 		];
-		var output = AFCH.removeDuplicateBanners( banners );
+		const output = AFCH.removeDuplicateBanners( banners );
 		expect( output ).toEqual( [
 			'{{WikiProject Australia}}',
 			'{{WikiProject Ontario}}'


### PR DESCRIPTION
Why
- Running old JS code through the mediawiki linter improves code quality and maintainability
- We can fully embrace ES6 now. The MediaWiki/Wikimedia compatibility policy allows it. We don't need to limit ourselves to ES5.

What
- add more eslint-config-wikimedia rules
- apply autofixes
- set un-autofixed errors to warn or off
- add server.js to .eslintignore since I couldn't figure out how to handle that error