### PR TITLE
improve wikicode writing to draft talk pages

### DIFF
--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -1732,7 +1732,9 @@
 			const uniqueBanners = [];
 			const bannerMap = {};
 			banners.forEach( ( banner ) => {
-				const bannerKey = banner.toLowerCase().match( /{{[^|}]+/ )[ 0 ];
+				let bannerKey = banner.toLowerCase().match( /{{[^|}]+/ )[ 0 ];
+				// get rid of whitespace at the end of the template name
+				bannerKey = bannerKey.trim();
 				if ( !bannerMap[ bannerKey ] ) {
 					uniqueBanners.push( banner );
 					bannerMap[ bannerKey ] = true;

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -1687,7 +1687,7 @@
 			}
 
 			// add disambiguation banner to array
-			if ( newAssessment === 'disambig' ) {
+			if ( newAssessment === 'Disambig' ) {
 				banners.push( '{{WikiProject Disambiguation}}' );
 			}
 

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -1669,7 +1669,7 @@
 			// Put at top for historical reasons. People are used to it being there.
 			banners.unshift(
 				'{{subst:WPAFC/article' +
-				( revId ? '|oldid=' + revId : '' ) +
+				( revId ? ' |oldid=' + revId : '' ) +
 				'}}'
 			);
 
@@ -1679,9 +1679,9 @@
 			// add biography banner to array
 			if ( isBiography ) {
 				banners.push(
-					'{{WikiProject Biography|living=' +
+					'{{WikiProject Biography |living=' +
 					( lifeStatus !== 'unknown' ? ( lifeStatus === 'living' ? 'yes' : 'no' ) : '' ) +
-					'|listas=' + subjectName +
+					' |listas=' + subjectName +
 					'}}'
 				);
 			}
@@ -1707,8 +1707,8 @@
 			// Add |class= to shell.
 			// Add |1=. Improves readability when lots of other parameters present.
 			wikicode = '{{WikiProject banner shell' +
-				( newAssessment ? '|class=' + newAssessment : '' ) +
-				'|1=\n' +
+				( newAssessment ? ' |class=' + newAssessment : '' ) +
+				' |1=\n' +
 				banners.join( '\n' ) +
 				'\n}}\n' +
 				wikicode;

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1600,7 +1600,7 @@
 					const isClassStub = $( this ).val() === 'Stub';
 					$afch.find( '#stubSorterWrapper' ).toggleClass( 'hidden', !isClassStub );
 					if ( isClassStub ) {
-						if ( mw.config.get( 'wgDBname' ) !== 'enwiki' ) {
+						if ( mw.config.get( 'wgDBname' ) !== 'enwiki' && mw.config.get( 'wgDBname' ) !== 'testwiki' ) {
 							console.warn( 'no stub sorting script available for this language wiki' );
 							return;
 						}

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1597,7 +1597,7 @@
 				// If draft is assessed as stub, show stub sorting
 				// interface using User:SD0001/StubSorter.js
 				$afch.find( '#newAssessment' ).on( 'change', function () {
-					const isClassStub = $( this ).val() === 'stub';
+					const isClassStub = $( this ).val() === 'Stub';
 					$afch.find( '#stubSorterWrapper' ).toggleClass( 'hidden', !isClassStub );
 					if ( isClassStub ) {
 						if ( mw.config.get( 'wgDBname' ) !== 'enwiki' ) {
@@ -1622,7 +1622,7 @@
 								$( '#stub-sorter-select' ).addClass( 'afch-input' );
 
 								if ( /\{\{[^{ ]*[sS]tub(\|.*?)?\}\}\s*/.test( pageText ) ) {
-									$afch.find( '#newAssessment' ).val( 'stub' ).trigger( 'chosen:updated' ).trigger( 'change' );
+									$afch.find( '#newAssessment' ).val( 'Stub' ).trigger( 'chosen:updated' ).trigger( 'change' );
 								}
 							} );
 						}

--- a/src/templates/tpl-submissions.html
+++ b/src/templates/tpl-submissions.html
@@ -73,15 +73,15 @@
 				<option value="" selected></option>
 				<option value="B">B-class</option>
 				<option value="C">C-class</option>
-				<option value="start">Start-class</option>
-				<option value="stub">Stub-class</option>
-				<option value="list">List-class</option>
-				<option value="disambig">Disambig-class</option>
-				<option value="template">Template-class</option>
-				<option value="redirect">Redirect-class</option>
-				<option value="portal">Portal-class</option>
-				<option value="project">Project-class</option>
-				<option value="na">NA-class</option>
+				<option value="Start">Start-class</option>
+				<option value="Stub">Stub-class</option>
+				<option value="List">List-class</option>
+				<option value="Disambig">Disambig-class</option>
+				<option value="Template">Template-class</option>
+				<option value="Redirect">Redirect-class</option>
+				<option value="Portal">Portal-class</option>
+				<option value="Project">Project-class</option>
+				<option value="NA">NA-class</option>
 			</select>
 		</div>
 

--- a/tests/test-core.js
+++ b/tests/test-core.js
@@ -454,4 +454,15 @@ describe( 'AFCH.removeDuplicateBanners', () => {
 			'{{WikiProject Ontario}}'
 		] );
 	} );
+
+	it( 'should handle a space at the end of the template name', () => {
+		const banners = [
+			'{{WikiProject Military history |Indian-task-force=yes}}',
+			'{{WikiProject Military history}}'
+		];
+		const output = AFCH.removeDuplicateBanners( banners );
+		expect( output ).toEqual( [
+			'{{WikiProject Military history |Indian-task-force=yes}}'
+		] );
+	} );
 } );

--- a/tests/test-core.js
+++ b/tests/test-core.js
@@ -374,7 +374,7 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 
 	it( 'user selects class = disambiguation', () => {
 		const wikicode = '';
-		const newAssessment = 'disambig';
+		const newAssessment = 'Disambig';
 		const revId = 592681;
 		const isBiography = false;
 		const newWikiProjects = [];
@@ -382,7 +382,7 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		const subjectName = '';
 		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
-`{{WikiProject banner shell|class=disambig|1=
+`{{WikiProject banner shell|class=Disambig|1=
 {{subst:WPAFC/article|oldid=592681}}
 {{WikiProject Disambiguation}}
 }}`

--- a/tests/test-core.js
+++ b/tests/test-core.js
@@ -132,8 +132,8 @@ describe( 'AFCH.addTalkPageBanners', () => {
 		const subjectName = '';
 		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
-`{{WikiProject banner shell|1=
-{{subst:WPAFC/article|oldid=592485}}
+`{{WikiProject banner shell |1=
+{{subst:WPAFC/article |oldid=592485}}
 }}`
 		);
 	} );
@@ -150,8 +150,8 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		const subjectName = '';
 		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
-`{{WikiProject banner shell|1=
-{{subst:WPAFC/article|oldid=592485}}
+`{{WikiProject banner shell |1=
+{{subst:WPAFC/article |oldid=592485}}
 }}
 
 == Hello ==
@@ -172,8 +172,8 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		const subjectName = '';
 		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
-`{{WikiProject banner shell|1=
-{{subst:WPAFC/article|oldid=592485}}
+`{{WikiProject banner shell |1=
+{{subst:WPAFC/article |oldid=592485}}
 {{WikiProject Women}}
 }}
 {{translated page|ar|بحيرة كناو|version=|small=no|insertversion=|section=}}`
@@ -193,8 +193,8 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		const subjectName = '';
 		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
-`{{WikiProject banner shell|1=
-{{subst:WPAFC/article|oldid=592485}}
+`{{WikiProject banner shell |1=
+{{subst:WPAFC/article |oldid=592485}}
 {{WikiProject Women}}
 }}
 {{translated page|ar|بحيرة كناو|version=|small=no|insertversion=|section=}}`
@@ -212,8 +212,8 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		const subjectName = '';
 		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
-`{{WikiProject banner shell|1=
-{{subst:WPAFC/article|oldid=592485}}
+`{{WikiProject banner shell |1=
+{{subst:WPAFC/article |oldid=592485}}
 {{WikiProject Women}}
 }}`
 		);
@@ -232,8 +232,8 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		const subjectName = '';
 		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
-`{{WikiProject banner shell|1=
-{{subst:WPAFC/article|oldid=592507}}
+`{{WikiProject banner shell |1=
+{{subst:WPAFC/article |oldid=592507}}
 {{WikiProject Women}}
 {{WikiProject Women's sport}}
 {{WikiProject Somalia}}
@@ -256,8 +256,8 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		const subjectName = '';
 		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
-`{{WikiProject banner shell|1=
-{{subst:WPAFC/article|oldid=592507}}
+`{{WikiProject banner shell |1=
+{{subst:WPAFC/article |oldid=592507}}
 {{WikiProject Women}}
 {{WikiProject Women's sport}}
 {{WikiProject Somalia}}
@@ -281,12 +281,12 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		const subjectName = 'Lazarut, Raluca';
 		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
-`{{WikiProject banner shell|1=
-{{subst:WPAFC/article|oldid=592507}}
+`{{WikiProject banner shell |1=
+{{subst:WPAFC/article |oldid=592507}}
 {{WikiProject Film}}
 {{WikiProject Women}}
 {{WikiProject Television}}
-{{WikiProject Biography|living=yes|listas=Lazarut, Raluca}}
+{{WikiProject Biography |living=yes |listas=Lazarut, Raluca}}
 {{WikiProject Romania}}
 }}`
 		);
@@ -307,8 +307,8 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		const subjectName = '';
 		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
-`{{WikiProject banner shell|1=
-{{subst:WPAFC/article|oldid=592507}}
+`{{WikiProject banner shell |1=
+{{subst:WPAFC/article |oldid=592507}}
 {{WikiProject Women}}
 {{WikiProject Women's sport}}
 {{WikiProject Somalia}}
@@ -326,9 +326,9 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		const subjectName = 'Jones, Bob';
 		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
-`{{WikiProject banner shell|class=B|1=
-{{subst:WPAFC/article|oldid=592496}}
-{{WikiProject Biography|living=yes|listas=Jones, Bob}}
+`{{WikiProject banner shell |class=B |1=
+{{subst:WPAFC/article |oldid=592496}}
+{{WikiProject Biography |living=yes |listas=Jones, Bob}}
 {{WikiProject Africa}}
 {{WikiProject Alabama}}
 }}`
@@ -345,9 +345,9 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		const subjectName = '';
 		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
-`{{WikiProject banner shell|1=
-{{subst:WPAFC/article|oldid=592496}}
-{{WikiProject Biography|living=no|listas=}}
+`{{WikiProject banner shell |1=
+{{subst:WPAFC/article |oldid=592496}}
+{{WikiProject Biography |living=no |listas=}}
 }}`
 		);
 	} );
@@ -365,8 +365,8 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		const subjectName = '';
 		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
-`{{WikiProject banner shell|1=
-{{subst:WPAFC/article|oldid=592496}}
+`{{WikiProject banner shell |1=
+{{subst:WPAFC/article |oldid=592496}}
 {{WikiProject Somalia}}
 }}`
 		);
@@ -382,8 +382,8 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		const subjectName = '';
 		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
-`{{WikiProject banner shell|class=Disambig|1=
-{{subst:WPAFC/article|oldid=592681}}
+`{{WikiProject banner shell |class=Disambig |1=
+{{subst:WPAFC/article |oldid=592681}}
 {{WikiProject Disambiguation}}
 }}`
 		);
@@ -400,8 +400,8 @@ I have a question. Can you help answer it? –[[User:Novem Linguae|<span style="
 		const subjectName = '';
 		const output = AFCH.addTalkPageBanners( wikicode, newAssessment, revId, isBiography, newWikiProjects, lifeStatus, subjectName );
 		expect( output ).toBe(
-`{{WikiProject banner shell|1=
-{{subst:WPAFC/article|oldid=592681}}
+`{{WikiProject banner shell |1=
+{{subst:WPAFC/article |oldid=592681}}
 {{OKA}}
 }}
 {{translated page|pl|Katowice Załęże|version=|small=no|insertversion=|section=}}`


### PR DESCRIPTION
- in wikicode, on draft talk pages, capitalize article assessments such as Start, Stub, etc.
    - Evad37/rater.js does this. Let's copy this practice, so that rater diffs are smaller. For example, the conversion of |class=start to |class=Start in this diff could have been avoided if AFCH had just written |class=Start in the first place: https://en.wikipedia.org/w/index.php?title=Talk:Phare_Circus&diff=next&oldid=1242207529
- when AFC accepting a stub, allow StubSorter user script to load on testwiki. for easier testing
- when writing template syntax, place a space before pipes. this is also to copy rater.
- fix a bug in the duplicate template detection algorithm. it will now handle a space at the end of the template name