### PR TITLE
tests: fix linter errors in scaffold.js

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -53,6 +53,7 @@
 		"no-shadow": "off",
 		"no-undef": "warn",
 		"no-underscore-dangle": "off",
+		"no-unused-vars": "warn",
 		"prefer-const": "warn",
 		"security/detect-non-literal-regexp": "off",
 		"security/detect-unsafe-regex": "off",

--- a/tests/scaffold.js
+++ b/tests/scaffold.js
@@ -8,7 +8,7 @@
 
 jest.autoMockOff();
 
-fs = require( 'fs' );
+const fs = require( 'fs' );
 
 // Mocked later
 mediaWiki = mw = {};
@@ -34,11 +34,7 @@ mw.loader = {
 
 const basePageHtml = fs.readFileSync( './tests/test-frame.html' ).toString();
 
-requireScript = function ( name ) {
-	return require( './../src/' + name );
-};
-
-setPageTitle = function ( title ) {
+const setPageTitle = function ( title ) {
 	mw.config.get.mockImplementation( ( requested ) => {
 		if ( requested === 'wgPageName' ) {
 			return title;
@@ -50,17 +46,17 @@ setPageTitle = function ( title ) {
 	} );
 };
 
-resetToBase = function () {
+const resetToBase = function () {
 	// Set the base document content using jsdom
 	document.documentElement.innerHtml = basePageHtml;
 	AFCH = undefined;
-	jQuery = $ = require( 'jquery' );
+	const jQuery = $ = require( 'jquery' );
 };
 
 resetToBase();
 
-resetToAFCApplicablePage = function () {
+const resetToAFCApplicablePage = function () {
 	resetToBase();
 	setPageTitle( 'Draft:Foo' );
-	requireScript( 'afch.js' );
+	require( './../src/afch.js' );
 };

--- a/tests/scaffold.js
+++ b/tests/scaffold.js
@@ -50,12 +50,12 @@ const resetToBase = function () {
 	// Set the base document content using jsdom
 	document.documentElement.innerHtml = basePageHtml;
 	AFCH = undefined;
-	const jQuery = $ = require( 'jquery' );
+	jQuery = $ = require( 'jquery' );
 };
 
 resetToBase();
 
-const resetToAFCApplicablePage = function () {
+resetToAFCApplicablePage = function () {
 	resetToBase();
 	setPageTitle( 'Draft:Foo' );
 	require( './../src/afch.js' );

--- a/tests/test-core.js
+++ b/tests/test-core.js
@@ -9,7 +9,7 @@ require( './scaffold.js' );
 
 resetToAFCApplicablePage();
 
-requireScript( 'modules/core.js' );
+require( './../src/modules/core.js' );
 
 // It's always good to start simple :)
 describe( 'AFCH', () => {


### PR DESCRIPTION
* fix some linter errors in scaffold.js
* get rid of requireScript() function because it triggered a security linter warning