### PR TITLE
Add cat - submission is a category decline option

### DIFF
--- a/src/templates/tpl-submissions.html
+++ b/src/templates/tpl-submissions.html
@@ -208,6 +208,7 @@
 				</optgroup>
 				<optgroup label="Invalid submissions">
 					<option value="blank">blank - Submission is blank</option>
+					<option value="cat">category - Submission is a category request</option>
 					<option value="lang">lang - Submission is not in English</option>
 					<option value="test">test - Submission appears to be a test edit</option>
 					<option value="redirect">redirect - Submission is a redirect request</option>

--- a/src/templates/tpl-submissions.html
+++ b/src/templates/tpl-submissions.html
@@ -208,7 +208,7 @@
 				</optgroup>
 				<optgroup label="Invalid submissions">
 					<option value="blank">blank - Submission is blank</option>
-					<option value="cat">category - Submission is a category request</option>
+					<option value="cat">cat - Submission is a category request</option>
 					<option value="lang">lang - Submission is not in English</option>
 					<option value="test">test - Submission appears to be a test edit</option>
 					<option value="redirect">redirect - Submission is a redirect request</option>


### PR DESCRIPTION
Add cat - submission is a category decline option. Will shortly open a edit-request at https://en.wikipedia.org/wiki/Template_talk:AfC_submission/comments as well for the comment update.

Fixes #363 