### PR TITLE
Allow up to 3 decline options

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1940,7 +1940,7 @@
 				no_results_text: 'Whoops, no reasons matched your search. Type "custom" to add a custom rationale instead.',
 				search_contains: true,
 				inherit_select_classes: true,
-				max_selected_options: 2
+				max_selected_options: 3
 			} );
 
 			// Set up jquery.chosen for the reject reason


### PR DESCRIPTION
Allow up to 3 decline options since many of the recent AI slop articles have too many issues. Having 3 declines will help highlight the major issues without having to link to violated policies in the comments.