### PR TITLE
Rewrite deployment script in node.js

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 server.js
+scripts/deploy.js

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pywikibot-*
 throttle.ctrl
 user-*
 venv/
+scripts/credentials.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "hogan.js": "^3.0.2"
       },
       "devDependencies": {
+        "commander": "^14.0.0",
         "eslint-config-wikimedia": "^0.28.2",
         "grunt": "^1.4.1",
         "grunt-autoprefixer": "^3.0.4",
@@ -21,7 +22,9 @@
         "grunt-eslint": "^24.3.0",
         "grunt-exec": "^3.0.0",
         "jest-cli": "^27.0.6",
-        "jquery": "^3.6.0"
+        "jquery": "^3.6.0",
+        "mwn": "^3.0.1",
+        "simple-git": "^3.28.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1168,6 +1171,23 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@mdn/browser-compat-data": {
       "version": "5.5.48",
       "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.5.48.tgz",
@@ -1358,6 +1378,13 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "16.0.9",
@@ -1751,6 +1778,35 @@
         "caniuse-db": "^1.0.30000153"
       }
     },
+    "node_modules/axios": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.5.1.tgz",
@@ -1951,6 +2007,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2149,6 +2219,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/comment-parser": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
@@ -2269,12 +2349,13 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -2403,6 +2484,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -2466,6 +2562,55 @@
       "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es6-promise": {
@@ -3388,6 +3533,27 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -3470,6 +3636,31 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -3477,6 +3668,20 @@
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stdin": {
@@ -3629,6 +3834,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
@@ -4200,6 +4418,35 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -5710,6 +5957,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/maxmin": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-3.0.0.tgz",
@@ -5830,10 +6087,55 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mwn": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mwn/-/mwn-3.0.1.tgz",
+      "integrity": "sha512-FuANXsGtDbkRYd4c2we7veVasX6eicCIzX/bKS7mrR/3c1FlPDZKSsSSIuDhWOx008OCoTFyL8j4ayekx0rvyQ==",
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "dependencies": {
+        "@types/node": "^14.18.63",
+        "@types/tough-cookie": "^4.0.5",
+        "axios": "^1.8.3",
+        "chalk": "^4.1.2",
+        "form-data": "^4.0.2",
+        "oauth-1.0a": "^2.2.6",
+        "tough-cookie": "^4.1.4",
+        "types-mediawiki-api": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/mwn/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mwn/node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -5947,6 +6249,13 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.12.tgz",
       "integrity": "sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w==",
       "dev": true
+    },
+    "node_modules/oauth-1.0a": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/oauth-1.0a/-/oauth-1.0a-2.2.6.tgz",
+      "integrity": "sha512-6bkxv3N4Gu5lty4viIcIAnq5GbxECviMBeKR3WX/q87SPQ8E8aursPZUtsXDnxCs787af09WPRBLqYrf/lwoYQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object.defaults": {
       "version": "1.1.0",
@@ -6433,6 +6742,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -6861,6 +7177,22 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/simple-git": {
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.28.0.tgz",
+      "integrity": "sha512-Rs/vQRwsn1ILH1oBUy8NucJlXmnnLeLCfcvbSehkPzbv3wwoFWIdtfd6Ndo6ZPhlPsCZ60CPI4rxurnwAa+a2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -7261,6 +7593,13 @@
       "dependencies": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "node_modules/types-mediawiki-api": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/types-mediawiki-api/-/types-mediawiki-api-2.0.0.tgz",
+      "integrity": "sha512-JeAm+5vD0Fe131UBt8ihJyRtXQlO4Zj180mOE3fcsdBLchqn1+ZfWBvJhBknd+hMalJ2H4DmsTzmbtDRB/sSYQ==",
+      "dev": true,
+      "license": "GPL-3.0-or-later"
     },
     "node_modules/typescript": {
       "version": "5.5.4",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,14 @@
   },
   "scripts": {
     "test": "grunt test",
-    "lint": "grunt lint"
+    "lint": "grunt lint",
+    "deploy": "node scripts/deploy.js"
   },
   "dependencies": {
     "hogan.js": "^3.0.2"
   },
   "devDependencies": {
+    "commander": "^14.0.0",
     "eslint-config-wikimedia": "^0.28.2",
     "grunt": "^1.4.1",
     "grunt-autoprefixer": "^3.0.4",
@@ -29,7 +31,9 @@
     "grunt-eslint": "^24.3.0",
     "grunt-exec": "^3.0.0",
     "jest-cli": "^27.0.6",
-    "jquery": "^3.6.0"
+    "jquery": "^3.6.0",
+    "mwn": "^3.0.1",
+    "simple-git": "^3.28.0"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/scripts/credentials.example.json
+++ b/scripts/credentials.example.json
@@ -1,0 +1,5 @@
+{
+	"site": "https://en.wikipedia.org/w/api.php",
+	"username": "Your username@Bot task",
+	"password": "Your password"
+}

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -48,7 +48,7 @@ function resolveApiUrl(site) {
         .option('-u, --username <username>', 'Wiki login username')
         .option('-p, --password <password>', 'Wiki login password')
         .option('-a, --accessToken <token>', 'OAuth2 access token (in place of username and password)')
-        .option('-b, --base <root>', 'Base page name', 'MediaWiki:Gadget-')
+        .option('-b, --base <base>', 'Base page name', 'MediaWiki:Gadget-')
         .option('-f, --force', 'Add --force flag while running grunt build')
         .allowUnknownOption(false)
         .parse(process.argv);
@@ -83,9 +83,10 @@ function resolveApiUrl(site) {
     const branch = (await git.branch()).current;
     const sha1 = (await git.revparse(['HEAD']));
     const header = `/* Uploaded from https://github.com/wikimedia-gadgets/afc-helper, commit: ${sha1} (${branch}) */\n`;
-    const isMainGadget = (conf.site === 'enwiki') && (conf.base === 'MediaWiki:Gadget-');
+    const hostname = new URL(apiUrl).hostname;
+    const isMainGadget = (hostname === 'en.wikipedia.org') && (conf.base === 'MediaWiki:Gadget-');
 
-    console.log(`Deploying to ${new URL(apiUrl).hostname} with base ${conf.base} ...`);
+    console.log(`Deploying to ${hostname} with base ${conf.base} ...`);
 
     // Login
     let bot;
@@ -110,6 +111,7 @@ function resolveApiUrl(site) {
         const pageTitle = conf.base + pageName;
 
         let content = header + fs.readFileSync(filePath, 'utf8');
+        content = content.replace(/MediaWiki:Gadget-/g, conf.base);
         if (isMainGadget) {
             content = content.replace('AFCH.consts.beta = true;', 'AFCH.consts.beta = false;');
         }
@@ -124,5 +126,5 @@ function resolveApiUrl(site) {
         }
     }
 
-    console.log(`AFCH uploaded to ${new URL(apiUrl).hostname} successfully!`);
+    console.log(`AFCH uploaded to ${hostname} successfully!`);
 })();

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const { Command } = require('commander');
+const { Mwn } = require('mwn');
+const simpleGit = require('simple-git');
+
+const TARGETS = {
+    // Mapping of files in build directory to unprefixed page names
+    'afch.js': 'afchelper.js',
+    'afch.css': 'afchelper.css',
+    'modules/core.js': 'afchelper.js/core.js',
+    'modules/submissions.js': 'afchelper.js/submissions.js',
+    'templates/tpl-preferences.html': 'afchelper.js/tpl-preferences.js',
+    'templates/tpl-submissions.html': 'afchelper.js/tpl-submissions.js',
+};
+
+function readCredentials() {
+    const filePath = path.join(__dirname, 'credentials.json');
+    if (fs.existsSync(filePath)) {
+        try {
+            return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        } catch (e) {
+            exit('Failed to parse scripts/credentials.json: ' + e);
+        }
+    }
+    return {};
+}
+
+function exit(msg) {
+    console.error('ERROR: ' + msg);
+    process.exit(1);
+}
+
+function resolveApiUrl(site) {
+    if (site === 'enwiki') return 'https://en.wikipedia.org/w/api.php';
+    if (site === 'testwiki') return 'https://test.wikipedia.org/w/api.php';
+    if (/^https?:\/\//.test(site) && site.endsWith('api.php')) return site;
+    return null;
+}
+
+(async () => {
+    const program = new Command();
+    program
+        .option('-s, --site <url>', 'enwiki, testwiki, or a full wiki API endpoint')
+        .option('-u, --username <username>', 'Wiki login username')
+        .option('-p, --password <password>', 'Wiki login password')
+        .option('-a, --accessToken <token>', 'OAuth2 access token (in place of username and password)')
+        .option('-b, --base <root>', 'Base page name', 'MediaWiki:Gadget-')
+        .option('-f, --force', 'Add --force flag while running grunt build')
+        .allowUnknownOption(false)
+        .parse(process.argv);
+
+    // Merge CLI > credentials.json
+    const conf = {
+        ...readCredentials(),
+        ...program.opts()
+    }
+
+    const apiUrl = resolveApiUrl(conf.site);
+    if (!apiUrl) {
+        exit('Missing or invalid --site! Pass enwiki, testwiki, or a full MediaWiki API URL, eg. https://en.wikipedia.org/w/api.php');
+    }
+    if ((!conf.username || !conf.password) && !conf.accessToken) {
+        exit(`Incomplete login credentials: please provide either --accessToken or --username and --password. Or set them in scripts/credentials.json`);
+    }
+
+    // Build step
+    let buildCmd = 'grunt build';
+    if (conf.force) buildCmd += ' --force';
+    console.log('Building afc-helper using', buildCmd);
+    const build = spawnSync(buildCmd, { shell: true, stdio: 'pipe' });
+    if (build.error || !build.stdout.toString().includes('Done')) {
+        exit('Build failed:', build.stdout.toString() || build.error);
+    } else {
+        console.log('Build succeeded!');
+    }
+
+    // Git info
+    const git = simpleGit();
+    const branch = (await git.branch()).current;
+    const sha1 = (await git.revparse(['HEAD']));
+    const header = `/* Uploaded from https://github.com/wikimedia-gadgets/afc-helper, commit: ${sha1} (${branch}) */\n`;
+    const isMainGadget = (conf.site === 'enwiki') && (conf.base === 'MediaWiki:Gadget-');
+
+    console.log(`Deploying to ${new URL(apiUrl).hostname} with base ${conf.base} ...`);
+
+    // Login
+    let bot;
+    try {
+        bot = await Mwn.init({
+            apiUrl,
+            username: conf.username,
+            password: conf.password,
+            OAuth2AccessToken: conf.accessToken,
+            userAgent: 'https://github.com/wikimedia-gadgets/afc-helper deploy.js (mwn)',
+            defaultParams: {
+                assert: 'user',
+                maxlag: 1000000,
+            }
+        });
+    } catch (e) {
+        exit('Login failed: ', e);
+    }
+
+    for (const [fileName, pageName] of Object.entries(TARGETS)) {
+        const filePath = path.join(__dirname, '../build', fileName);
+        const pageTitle = conf.base + pageName;
+
+        let content = header + fs.readFileSync(filePath, 'utf8');
+        if (isMainGadget) {
+            content = content.replace('AFCH.consts.beta = true;', 'AFCH.consts.beta = false;');
+        }
+        const editSummary = `Updating AFCH: ${branch} @ ${sha1.slice(0, 6)}`
+
+        console.log(`Deploying build/${fileName} to ${pageTitle} ...`);
+        const saveResponse = await bot.save(pageTitle, content, editSummary);
+        if (saveResponse.nochange) {
+            console.log(`\tNo change from edit`);
+        } else {
+            console.log(`\tSaved ${pageTitle}`);
+        }
+    }
+
+    console.log(`AFCH uploaded to ${new URL(apiUrl).hostname} successfully!`);
+})();

--- a/src/afch.js
+++ b/src/afch.js
@@ -31,10 +31,10 @@
 
 	// These next two statements (setting beta and baseurl) may be modified
 	// by the uploading script! If you change them, check that the uploading
-	// script at scripts/upload.py doesn't break.
+	// script at scripts/deploy.js doesn't break.
 	AFCH.consts.beta = true;
 	AFCH.consts.baseurl = AFCH.consts.scriptpath +
-		'?action=raw&ctype=text/javascript&title=MediaWiki:Gadget-afch.js';
+		'?action=raw&ctype=text/javascript&title=MediaWiki:Gadget-afchelper.js';
 
 	$.getScript( AFCH.consts.baseurl + '/core.js' ).done( () => {
 		const loaded = AFCH.load( 'submissions' ); // perhaps eventually there will be more modules besides just 'submissions'

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -199,7 +199,7 @@
 
 			if ( AFCH.consts.beta ) {
 				// Load minified css
-				mw.loader.load( AFCH.consts.scriptpath + '?action=raw&ctype=text/css&title=MediaWiki:Gadget-afch.css', 'text/css' );
+				mw.loader.load( AFCH.consts.scriptpath + '?action=raw&ctype=text/css&title=MediaWiki:Gadget-afchelper.css', 'text/css' );
 				promise = mw.loader.using( [
 					'jquery.chosen',
 					'jquery.spinner',


### PR DESCRIPTION
To use, create the file `scripts/credentials.json` with the following format:

```
{
  "site": "http://localhost:4000/api.php",
  "username": "Wikiuser@bp5",
  "password": "12345678901234567890123456789012"
}
```

Replacing the values as necessary. Alternatively, the parameters can be specified via cli params (`--site`, `--username`, `--password`). Authentication via OAuth2 access token (`--accessToken`) is also supported to facilitate running automatically via a web frontend in the future.

Then run `node scripts/deploy.js` (or use the shortcut `npm run deploy`). Full cli documentation is available with the script's `-h`/`--help` flag.

Closes #413