### PR TITLE
submissions: cleanUp: don't remove certain comments when declining

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -524,9 +524,6 @@
 			'Please don\'t change anything and press save',
 			'Carry on from here, and delete this comment.',
 			'Please leave this line alone!',
-			'Important, do not remove this line before (template|article) has been created.',
-			'Important, do not remove anything above this line before (template|article) has been created.',
-			'Do not remove this line!',
 			'Just press the "Save page" button below without changing anything! Doing so will submit your article submission for review. ' +
 				'Once you have saved this page you will find a new yellow \'Review waiting\' box at the bottom of your submission page. ' +
 				'If you have submitted your page previously,(?: either)? the old pink \'Submission declined\' template or the old grey ' +
@@ -568,7 +565,10 @@
 				'Metadata: see \\[\\[Wikipedia:Persondata\\]\\].',
 				'See http://en.wikipedia.org/wiki/Wikipedia:Footnotes on how to create references using\\<ref\\>\\<\\/ref\\> tags, these references will then appear here automatically',
 				'(After listing your sources please cite them using inline citations and place them after the information they cite.|Inline citations added to your article will automatically display here.) ' +
-					'(Please see|See) ((https?://)?en.wikipedia.org/wiki/(Wikipedia|WP):REFB|\\[\\[Wikipedia:REFB\\]\\]) for instructions on how to add citations.'
+					'(Please see|See) ((https?://)?en.wikipedia.org/wiki/(Wikipedia|WP):REFB|\\[\\[Wikipedia:REFB\\]\\]) for instructions on how to add citations.',
+				'Important, do not remove this line before (template|article) has been created.',
+				'Important, do not remove anything above this line before (template|article) has been created.',
+				'Do not remove this line!'
 			);
 		} else {
 			// If not yet accepted, comment out cats

--- a/tests/test-submissions.js
+++ b/tests/test-submissions.js
@@ -106,7 +106,7 @@ describe( 'AFCH.Text.cleanUp', () => {
 		expect( output ).toBe( expectedOutput );
 	} );
 
-	it( 'should remove <!-- Important, do not remove this line... -->', () => {
+	it( 'should remove <!-- Important, do not remove this line... --> when accepting', () => {
 		const wikicode =
 `{{AfC submission|t||ts=20220716175214|u=Guillermind81|ns=118|demo=}}<!-- Important, do not remove this line before article has been created. -->
 {{short description|Astronomical treatise by Christiaan Huygens}}
@@ -120,7 +120,7 @@ describe( 'AFCH.Text.cleanUp', () => {
 		expect( output ).toBe( expectedOutput );
 	} );
 
-	it( 'should remove <!-- Important, do not remove anything above this line... -->', () => {
+	it( 'should remove <!-- Important, do not remove anything above this line... --> when accepting', () => {
 		const wikicode =
 `{{AfC submission|t||ts=20220716175214|u=Guillermind81|ns=118|demo=}}<!-- Important, do not remove anything above this line before article has been created. -->
 {{short description|Astronomical treatise by Christiaan Huygens}}
@@ -134,7 +134,7 @@ describe( 'AFCH.Text.cleanUp', () => {
 		expect( output ).toBe( expectedOutput );
 	} );
 
-	it( 'should remove <!-- Do not remove this line! -->', () => {
+	it( 'should remove <!-- Do not remove this line! --> when accepting', () => {
 		const wikicode =
 `{{AFC submission|||u=172.116.210.112|ns=118|ts=20210128174245}}
 <!-- Do not remove this line! -->{{short description|Upcoming American supernatural horror film}}
@@ -143,6 +143,48 @@ describe( 'AFCH.Text.cleanUp', () => {
 		const expectedOutput =
 `{{AFC submission|||u=172.116.210.112|ns=118|ts=20210128174245}}
 {{short description|Upcoming American supernatural horror film}}
+`;
+		const output = ( new AFCH.Text( wikicode ) ).cleanUp( isAccept );
+		expect( output ).toBe( expectedOutput );
+	} );
+
+	it( 'should not remove <!-- Important, do not remove this line... --> when declining', () => {
+		const wikicode =
+`{{AfC submission|t||ts=20220716175214|u=Guillermind81|ns=118|demo=}}<!-- Important, do not remove this line before article has been created. -->
+{{short description|Astronomical treatise by Christiaan Huygens}}
+`;
+		const isAccept = false;
+		const expectedOutput =
+`{{AfC submission|t||ts=20220716175214|u=Guillermind81|ns=118|demo=}}<!-- Important, do not remove this line before article has been created. -->
+{{short description|Astronomical treatise by Christiaan Huygens}}
+`;
+		const output = ( new AFCH.Text( wikicode ) ).cleanUp( isAccept );
+		expect( output ).toBe( expectedOutput );
+	} );
+
+	it( 'should not remove <!-- Important, do not remove anything above this line... --> when declining', () => {
+		const wikicode =
+`{{AfC submission|t||ts=20220716175214|u=Guillermind81|ns=118|demo=}}<!-- Important, do not remove anything above this line before article has been created. -->
+{{short description|Astronomical treatise by Christiaan Huygens}}
+`;
+		const isAccept = false;
+		const expectedOutput =
+`{{AfC submission|t||ts=20220716175214|u=Guillermind81|ns=118|demo=}}<!-- Important, do not remove anything above this line before article has been created. -->
+{{short description|Astronomical treatise by Christiaan Huygens}}
+`;
+		const output = ( new AFCH.Text( wikicode ) ).cleanUp( isAccept );
+		expect( output ).toBe( expectedOutput );
+	} );
+
+	it( 'should not remove <!-- Do not remove this line! --> when declining', () => {
+		const wikicode =
+`{{AFC submission|||u=172.116.210.112|ns=118|ts=20210128174245}}
+<!-- Do not remove this line! -->{{short description|Upcoming American supernatural horror film}}
+`;
+		const isAccept = false;
+		const expectedOutput =
+`{{AFC submission|||u=172.116.210.112|ns=118|ts=20210128174245}}
+<!-- Do not remove this line! -->{{short description|Upcoming American supernatural horror film}}
 `;
 		const output = ( new AFCH.Text( wikicode ) ).cleanUp( isAccept );
 		expect( output ).toBe( expectedOutput );


### PR DESCRIPTION
I think the point of these comments is to discourage submitters from deleting old decline reasons and deleting or modifying anything above the lead, which makes sense. Let's only delete these comments on accept, rather than also deleting them on decline.