### PR TITLE
deploy.js: add "deploy.js" to edit summary

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -16,6 +16,7 @@ const TARGETS = {
     'templates/tpl-preferences.html': 'afchelper.js/tpl-preferences.js',
     'templates/tpl-submissions.html': 'afchelper.js/tpl-submissions.js',
 };
+const EDIT_SUMMARY_ADVERT = ' (deploy.js)';
 
 function readCredentials() {
     const filePath = path.join(__dirname, 'credentials.json');
@@ -115,7 +116,7 @@ function resolveApiUrl(site) {
         if (isMainGadget) {
             content = content.replace('AFCH.consts.beta = true;', 'AFCH.consts.beta = false;');
         }
-        const editSummary = `Updating AFCH: ${branch} @ ${sha1.slice(0, 6)}`
+        const editSummary = `Updating AFCH: ${branch} @ ${sha1.slice(0, 6)} ${EDIT_SUMMARY_ADVERT}`
 
         console.log(`Deploying build/${fileName} to ${pageTitle} ...`);
         const saveResponse = await bot.save(pageTitle, content, editSummary);


### PR DESCRIPTION
I feel that the deploy script should indicate that the edit is from the script in the edit summary somewhere. It does not do so when running `npm run deploy` from a command line.

We could do a tag instead, but appending to the edit summary seems simplest.