### PR TITLE
afch.js: remove sandbox check & update comment

### DIFF
--- a/src/afch.js
+++ b/src/afch.js
@@ -3,9 +3,9 @@
 	// Check that we're in a namespace that uses AFCH.
 	// In the gadget, this is checked by the gadgets extension and this check is not needed, since we defined namespaces in MediaWiki:Gadgets-definition.
 	// But in server.js, we don't get this gadget check, so we need to check it manually. Else you'll get AFCH appearing on the Main Page :)
-	const draftNamespace = 118;
 	const userNamespace = 2;
-	if ( [draftNamespace, userNamespace].includes( mw.config.get( 'wgNamespaceNumber' ) ) ) {
+	const draftNamespace = 118;
+	if ( ![draftNamespace, userNamespace].includes( mw.config.get( 'wgNamespaceNumber' ) ) ) {
 		return;
 	}
 

--- a/src/afch.js
+++ b/src/afch.js
@@ -5,7 +5,7 @@
 	// But in server.js, we don't get this gadget check, so we need to check it manually. Else you'll get AFCH appearing on the Main Page :)
 	const userNamespace = 2;
 	const draftNamespace = 118;
-	if ( ![draftNamespace, userNamespace].includes( mw.config.get( 'wgNamespaceNumber' ) ) ) {
+	if ( ![ draftNamespace, userNamespace ].includes( mw.config.get( 'wgNamespaceNumber' ) ) ) {
 		return;
 	}
 

--- a/src/afch.js
+++ b/src/afch.js
@@ -1,19 +1,9 @@
 // <nowiki>
 ( function () {
-	// Check that we're in the right namespace and on the right page
+	// Check that we're in the right namespace
+	// In the gadget, this is checked by ResourceLoader and not needed.
+	// But in server.js, we need to check it manually. Else you'll get AFCH appearing on the Main Page :)
 	switch ( mw.config.get( 'wgNamespaceNumber' ) ) {
-		case 4: // Wikipedia
-		case 5: { // Wikipedia talk
-			const pageName = mw.config.get( 'wgTitle' );
-			// return nothing for now, all drafts are now under Draft namespace
-			// currently only the article submission script is running here.
-			// to be used when script(s) for other modules such as category and
-			// redirect requests are reintergrated into here.
-			if ( pageName !== 'Articles for creation/sandbox' ) {
-				return;
-			}
-			break;
-		}
 		case 2: // User
 		case 118: // Draft
 			break;

--- a/src/afch.js
+++ b/src/afch.js
@@ -1,8 +1,8 @@
 // <nowiki>
 ( function () {
 	// Check that we're in a namespace that uses AFCH.
-	// In the gadget, this is checked by the gadgets extension and this check is not needed, since we defined namespaces in MediaWiki:Gadgets-definition.
-	// But in server.js, we don't get this gadget check, so we need to check it manually. Else you'll get AFCH appearing on the Main Page :)
+	// In the gadget, namespaces are checked by the gadgets extension, and the below check is not needed, since we defined namespaces in MediaWiki:Gadgets-definition.
+	// But in server.js, we don't get this gadget check, so we need to check it below. Else you'll get AFCH appearing on the Main Page :)
 	const userNamespace = 2;
 	const draftNamespace = 118;
 	if ( ![ draftNamespace, userNamespace ].includes( mw.config.get( 'wgNamespaceNumber' ) ) ) {

--- a/src/afch.js
+++ b/src/afch.js
@@ -1,14 +1,12 @@
 // <nowiki>
 ( function () {
-	// Check that we're in the right namespace
-	// In the gadget, this is checked by ResourceLoader and not needed.
-	// But in server.js, we need to check it manually. Else you'll get AFCH appearing on the Main Page :)
-	switch ( mw.config.get( 'wgNamespaceNumber' ) ) {
-		case 2: // User
-		case 118: // Draft
-			break;
-		default:
-			return;
+	// Check that we're in a namespace that uses AFCH.
+	// In the gadget, this is checked by the gadgets extension and this check is not needed, since we defined namespaces in MediaWiki:Gadgets-definition.
+	// But in server.js, we don't get this gadget check, so we need to check it manually. Else you'll get AFCH appearing on the Main Page :)
+	const draftNamespace = 118;
+	const userNamespace = 2;
+	if ( [draftNamespace, userNamespace].includes( mw.config.get( 'wgNamespaceNumber' ) ) ) {
+		return;
 	}
 
 	// Initialize the AFCH object


### PR DESCRIPTION
Removing sandbox check because that sandbox page is old and just redirects to WP:AFC. This also lets us simplify our namespace checking down to 2 namespaces.

Adding a comment about ResourceLoader now doing some namespace checking, and why we're keeping this namespace checking code.

I changed MediaWiki:Gadgets-definition to do the namespace check in https://en.wikipedia.org/w/index.php?title=MediaWiki:Gadgets-definition&diff=prev&oldid=1297769296 and https://test.wikipedia.org/w/index.php?title=MediaWiki:Gadgets-definition&diff=prev&oldid=664605

Related #415