### PR TITLE
build: don't hardcode JS version

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,10 +20,7 @@
 		{
 			"files": [
 				"tests/*"
-			],
-			"parserOptions": {
-				"ecmaVersion": 6
-			}
+			]
 		}
 	],
 	"rules": {
@@ -41,8 +38,6 @@
 		"unicorn/prefer-string-slice": "off",
 
 		"eqeqeq": "warn",
-		"es-x/no-array-prototype-includes": "warn",
-		"es-x/no-object-values": "warn",
 		"es-x/no-regexp-s-flag": "warn",
 		"no-global-assign": "warn",
 		"no-implicit-globals": "warn",


### PR DESCRIPTION
rather, inherit this from eslint-config-wikimedia. right now it'll inherit ES2017

ES2017 also means a couple of es-x rule warnings/errors will go away. so we can remove those from our config too