### PR TITLE
jest: set maxWorkers = 1 when running in deploy service

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,16 @@
+// https://jestjs.io/docs/configuration
+
+const config = {
+	testEnvironment: 'jsdom',
+	testMatch: [
+		'**/tests/**/test-*.[jt]s?(x)',
+		'**/?(*.)+(spec|test).[jt]s?(x)'
+	]
+};
+
+// Check whether we're running on gadget-deploy.toolforge.org
+if (process.env.IN_DEPLOY_SERVICE) {
+	config.maxWorkers = 1;
+}
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -35,12 +35,5 @@
     "jquery": "^3.6.0",
     "mwn": "^3.0.1",
     "simple-git": "^3.28.0"
-  },
-  "jest": {
-    "testEnvironment": "jsdom",
-    "testMatch": [
-      "**/tests/**/test-*.[jt]s?(x)",
-      "**/?(*.)+(spec|test).[jt]s?(x)"
-    ]
   }
 }


### PR DESCRIPTION
Moving existing config from package.json to jest.config.js, since all config need to be in the same place, and package.json doesn't support conditional logic.

Solves #427