### PR TITLE
Remove minification and vendor-prefixing while building LESS files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,15 +43,6 @@ module.exports = function ( grunt ) {
 			}
 		},
 
-		autoprefixer: {
-			build: {
-				expand: true,
-				cwd: 'build',
-				src: [ '**/*.css' ],
-				dest: 'build'
-			}
-		},
-
 		cssmin: {
 			build: {
 				files: {
@@ -62,7 +53,6 @@ module.exports = function ( grunt ) {
 
 	} );
 
-	grunt.loadNpmTasks( 'grunt-autoprefixer' );
 	grunt.loadNpmTasks( 'grunt-contrib-clean' );
 	grunt.loadNpmTasks( 'grunt-contrib-concat' );
 	grunt.loadNpmTasks( 'grunt-contrib-copy' );
@@ -72,7 +62,7 @@ module.exports = function ( grunt ) {
 	grunt.registerTask(
 		'styling',
 		'Compiles LESS files to CSS and minifies them into one file.',
-		[ 'less', 'autoprefixer', 'cssmin', 'clean:styling' ]
+		[ 'less', 'cssmin', 'clean:styling' ]
 	);
 
 	grunt.registerTask(

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,29 +24,13 @@ module.exports = function ( grunt ) {
 		clean: {
 			build: {
 				src: [ 'build' ]
-			},
-			styling: {
-				src: [ 'build/less' ]
 			}
 		},
 
 		less: {
-			options: {
-				cleancss: true
-			},
-			files: {
-				expand: true,
-				cwd: 'src',
-				src: [ 'less/*.less' ],
-				dest: 'build',
-				ext: '.css'
-			}
-		},
-
-		cssmin: {
 			build: {
 				files: {
-					'build/afch.css': [ 'build/**/*.css' ]
+					'build/afch.css': [ 'src/less/general.less', 'src/less/submissions.less' ]
 				}
 			}
 		}
@@ -56,19 +40,12 @@ module.exports = function ( grunt ) {
 	grunt.loadNpmTasks( 'grunt-contrib-clean' );
 	grunt.loadNpmTasks( 'grunt-contrib-concat' );
 	grunt.loadNpmTasks( 'grunt-contrib-copy' );
-	grunt.loadNpmTasks( 'grunt-contrib-cssmin' );
 	grunt.loadNpmTasks( 'grunt-contrib-less' );
-
-	grunt.registerTask(
-		'styling',
-		'Compiles LESS files to CSS and minifies them into one file.',
-		[ 'less', 'cssmin', 'clean:styling' ]
-	);
 
 	grunt.registerTask(
 		'build',
 		'Moves files to the /build directory, and minifies CSS.',
-		[ 'clean:build', 'copy', 'concat:dependencies', 'styling' ]
+		[ 'clean:build', 'copy', 'concat:dependencies', 'less' ]
 	);
 
 	grunt.registerTask( 'default', [ 'build' ] );

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "grunt-contrib-clean": "^2.0.0",
         "grunt-contrib-concat": "^1.0.1",
         "grunt-contrib-copy": "^1.0.0",
-        "grunt-contrib-cssmin": "^4.0.0",
         "grunt-contrib-less": "^3.0.0",
         "jest-cli": "^27.0.6",
         "jquery": "^3.6.0",
@@ -2158,29 +2157,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/clean-css": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
-      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 10.0"
-      }
-    },
-    "node_modules/clean-css/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/clean-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
@@ -2558,13 +2534,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.177",
@@ -3537,32 +3506,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/figures/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -4287,21 +4230,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/grunt-contrib-cssmin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-4.0.0.tgz",
-      "integrity": "sha512-jXU+Zlk8Q8XztOGNGpjYlD/BDQ0n95IHKrQKtFR7Gd8hZrzgqiG1Ra7cGYc8h2DD9vkSFGNlweb9Q00rBxOK2w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "clean-css": "^5.0.1",
-        "maxmin": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      }
-    },
     "node_modules/grunt-contrib-less": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-less/-/grunt-contrib-less-3.0.0.tgz",
@@ -4420,20 +4348,6 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/gzip-size": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
-      "integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "duplexer": "^0.1.1",
-        "pify": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -6098,25 +6012,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/maxmin": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-3.0.0.tgz",
-      "integrity": "sha512-wcahMInmGtg/7c6a75fr21Ch/Ks1Tb+Jtoan5Ft4bAI0ZvJqyOw8kkM7e7p8hDSzY805vmxwHT50KcjGwKyJ0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "figures": "^3.2.0",
-        "gzip-size": "^5.1.1",
-        "pretty-bytes": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -6725,6 +6620,7 @@
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -6840,19 +6736,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/pretty-bytes": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
-      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pretty-format": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "commander": "^14.0.0",
         "eslint-config-wikimedia": "^0.30.0",
         "grunt": "^1.4.1",
-        "grunt-autoprefixer": "^3.0.4",
         "grunt-contrib-clean": "^2.0.0",
         "grunt-contrib-concat": "^1.0.1",
         "grunt-contrib-copy": "^1.0.0",
@@ -1680,16 +1679,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
-      "dev": true,
-      "license": "BSD-3-Clause OR MIT",
-      "engines": {
-        "node": ">=0.4.2"
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -1819,30 +1808,6 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/autoprefixer-core": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz",
-      "integrity": "sha512-1X4srCG0vAe2ArX9d3Kfkuo5yREFZwKE5mH+VHZHIhmx0V8UjDPAKmNgJlWxxNbCAraHiDPTcT2kc+3i73jR/Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "~0.4.0",
-        "caniuse-db": "^1.0.30000214",
-        "num2fraction": "^1.1.0",
-        "postcss": "~4.1.12"
-      }
-    },
-    "node_modules/autoprefixer-core/node_modules/browserslist": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz",
-      "integrity": "sha512-/JVhaf9S6ru3THyiuwX5j86pT79r5UtgwV3s6w+KpGlmUzPxfMbI5OBxO88iFtqgdqPuNirprachS3m1611qKA==",
-      "deprecated": "Browserslist 2 could fail on reading Browserslist >3.0 config used in other tools.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "caniuse-db": "^1.0.30000153"
-      }
     },
     "node_modules/axios": {
       "version": "1.10.0",
@@ -2121,13 +2086,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/caniuse-db": {
-      "version": "1.0.30001726",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001726.tgz",
-      "integrity": "sha512-fqR5/yyvxhW9+Jn6vsWmce258vpFKdaFn0YXlNsMrnvKoCdZ9IJHbXf4x13b37y+bG0T3sr+8UT5miVtFTAeGQ==",
-      "dev": true,
-      "license": "CC-BY-4.0"
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001726",
@@ -2539,15 +2497,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/diff": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.3.2.tgz",
-      "integrity": "sha512-9+sQRZoycCPesCSrnJci3QAbspUkUqJB9OidQlaSwsX0Nks2YigX2X0N4CaVmII2NlonNB2osJj9tALJFoVuIA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/diff-sequences": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
@@ -2730,13 +2679,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/es6-promise": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
-      "integrity": "sha512-oyOjMhyKMLEjOOtvkwg0G4pAzLQ9WdbbeX7WdqKzvYXu+UFgD0Zo/Brq5Q49zNmnGPPzV5rmYvrr0jz1zWx8Iw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -3897,16 +3839,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha512-F5aQMywwJ2n85s4hJPTT9RPxGmubonuB10MNYo17/xph174n2MIR33HRguhzVag10O/npM7SPk73LMZNP+FaWw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -4091,101 +4023,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/grunt-autoprefixer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-3.0.4.tgz",
-      "integrity": "sha512-WlLnLOGoQFI/IQj6vbx+Kx/KMmJn5g1Fkx6rcp5+9VRIFwN46uSSi3BC8HMteHTZ/KA+zAqST957TkoiSDIujw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "autoprefixer-core": "^5.1.7",
-        "chalk": "~1.0.0",
-        "diff": "~1.3.0",
-        "postcss": "^4.1.11"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      },
-      "peerDependencies": {
-        "grunt": ">=0.4.2"
-      }
-    },
-    "node_modules/grunt-autoprefixer/node_modules/ansi-regex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-      "integrity": "sha512-q5i8bFLg2wDfsuR56c1NzlJFPzVD+9mxhDrhqOGigEFa87OZHlF+9dWeGWzVTP/0ECiA/JUGzfzRr2t3eYORRw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/grunt-autoprefixer/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/grunt-autoprefixer/node_modules/chalk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
-      "integrity": "sha512-1TE3hpADga5iWinlcCpyhC7fTl9uQumLD8i2jJoJeVg7UbveY5jj7F6uCq8w0hQpSeLhaPn5QFe8e56toMVP1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^2.0.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^1.0.3",
-        "strip-ansi": "^2.0.1",
-        "supports-color": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/grunt-autoprefixer/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/grunt-autoprefixer/node_modules/strip-ansi": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-      "integrity": "sha512-2h8q2CP3EeOhDJ+jd932PRMpa3/pOJFGoF22J1U/DNbEK2gSW2DqeF46VjCXsSQXhC+k/l8/gaaRBQKL6hUPfQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^1.0.0"
-      },
-      "bin": {
-        "strip-ansi": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/grunt-autoprefixer/node_modules/supports-color": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
-      "integrity": "sha512-OHbMkscHFRcNWEcW80fYhCrzAjheSIBwJChpFaBqA6zEz53nxumqi6ukciRb/UA0/v2nDNMk28ce/uBbYRDsng==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "supports-color": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/grunt-cli": {
@@ -4596,33 +4433,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/has-ansi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
-      "integrity": "sha512-XwLzIec2hoj/LW9F3nCcQpEwZ5fDJ1LOc6SAgc0pz79CGiY9zmZhIkbf7OnK+tC36UhpQBa03HPt13QavGoF6Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^1.1.0",
-        "get-stdin": "^4.0.1"
-      },
-      "bin": {
-        "has-ansi": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-ansi/node_modules/ansi-regex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-      "integrity": "sha512-q5i8bFLg2wDfsuR56c1NzlJFPzVD+9mxhDrhqOGigEFa87OZHlF+9dWeGWzVTP/0ECiA/JUGzfzRr2t3eYORRw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/has-flag": {
@@ -5883,13 +5693,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/js-base64": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
-      "integrity": "sha512-f+5mYh8iF7FlF7zgmj/yqvvYQUHI0kAxGiLjIfNxZzqJ7RQNc4sjgp8crVJw0Kzv2O6aFGZWgMTnO71I9utHSg==",
-      "dev": true,
-      "license": "BSD"
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6587,13 +6390,6 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
-    "node_modules/num2fraction": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-      "integrity": "sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/nwsapi": {
       "version": "2.2.20",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
@@ -7022,18 +6818,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/postcss": {
-      "version": "4.1.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
-      "integrity": "sha512-aAutxE8MvL1bHylFMYb2c2nniFax8XDztHzZ+x5DVsNJnoW6VHvGSNSqdW3+ip255HCWfPjayVVFzMmyiL7opA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es6-promise": "~2.3.0",
-        "js-base64": "~2.1.8",
-        "source-map": "~0.4.2"
-      }
-    },
     "node_modules/postcss-selector-parser": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
@@ -7046,19 +6830,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/postcss/node_modules/source-map": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-      "integrity": "sha512-Y8nIfcb1s/7DcobUz1yOO1GSp7gyL+D9zLHDehT7iRESqGSxjJ448Sg7rvfgsRJCnKLdSl11uGf0s9X80cH0/A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "amdefine": ">=0.0.4"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "grunt-contrib-clean": "^2.0.0",
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-copy": "^1.0.0",
-    "grunt-contrib-cssmin": "^4.0.0",
     "grunt-contrib-less": "^3.0.0",
     "jest-cli": "^27.0.6",
     "jquery": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "commander": "^14.0.0",
     "eslint-config-wikimedia": "^0.30.0",
     "grunt": "^1.4.1",
-    "grunt-autoprefixer": "^3.0.4",
     "grunt-contrib-clean": "^2.0.0",
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-copy": "^1.0.0",

--- a/src/less/general.less
+++ b/src/less/general.less
@@ -46,6 +46,7 @@
 div.gradient-button, .gradient-button {
 	cursor: pointer;
 	text-decoration: none;
+	-webkit-user-select: none;
 	user-select: none;
 	transition: box-shadow .1s ease-in-out;
 
@@ -64,6 +65,7 @@ div.gradient-button, .gradient-button {
 	&.disabled {
 		background-color: @lightgray;
 		text-decoration: none;
+		-webkit-user-select: none;
 		user-select: none;
 		cursor: not-allowed;
 

--- a/src/less/minimal.less
+++ b/src/less/minimal.less
@@ -1,3 +1,0 @@
-/**
- * Alternative styling for submissions.js
- */


### PR DESCRIPTION
* Remove grunt-autoprefixer
  * The only CSS rule requiring vendor-prefixing is user-select: none. It's supported everywhere except for Safari which needs the -webkit- prefix. Added it manually and removed the grunt-autoprefixer dependency. All other CSS being used in the gadget is standard.

* Remove css minification
  * Remove grunt-cssmin dependency. CSS minification is unnecessary in the build as it anyway gets handled by ResourceLoader. This also makes the on-wiki CSS file readable.

* Remove minimal.less: empty and unused
