### PR TITLE
ci: don't run the linter task twice in PRs

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,6 +1,10 @@
 name: Linter
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
Should fix the below screenshot, bringing the number of CI checks on each PR from 3 to 2.

<img width="784" alt="image" src="https://github.com/user-attachments/assets/fc2b4bef-f777-4ce8-abe5-3c070f9be7bf" />