### PR TITLE
revert #436 tpl-submissions: make decline alias codes searchable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,3 @@ Below is a list of dependencies and what they are involved with, so you know wha
 - Add it to [[Template:AfC submission/comments/doc]]. [Example.](https://en.wikipedia.org/w/index.php?title=Template:AfC_submission/comments/doc&curid=39614945&diff=1305864471&oldid=1291414231)
 - Add it to [[Template:AfC submission/comments/testcases]]. [Example.](https://en.wikipedia.org/w/index.php?title=Template:AfC_submission/comments/testcases&curid=40093415&diff=1305869528&oldid=1281911402)
 - Write an AFCH patch that adds it to AFCH. [Example.](https://github.com/wikimedia-gadgets/afc-helper/pull/395/files)
-    - If that patch has multiple codes (for example, llm and ai both refer to the artifical intelligence decline reason), add "(alias: llm)" or similar to the end of it, so that all codes show up in search results.
-    - Example: `<option value="ai">ai - Submission appears to be a large language model output (alias: llm)</option>`

--- a/src/templates/tpl-submissions.html
+++ b/src/templates/tpl-submissions.html
@@ -196,20 +196,20 @@
 				<optgroup label="Notability">
 					<option value="neo">neo - Submission is about a neologism not yet shown to meet notability guidelines</option>
 					<option value="web">web - Submission is about web content not yet shown to meet notability guidelines</option>
-					<option value="prof">prof - Submission is about a professor not yet shown to meet notability guidelines (alias: academic)</option>
-					<option value="athlete">athlete - Submission is about an athlete not yet shown to meet notability guidelines (alias: sport)</option>
-					<option value="music">music - Submission is about a musician or musical work not yet shown to meet notability guidelines (aliases: m, band)</option>
+					<option value="prof">prof - Submission is about a professor not yet shown to meet notability guidelines</option>
+					<option value="athlete">athlete - Submission is about an athlete not yet shown to meet notability guidelines</option>
+					<option value="music">music - Submission is about a musician or musical work not yet shown to meet notability guidelines</option>
 					<option value="film">film - Submission is about a film not yet shown to meet notability guidelines</option>
 					<option value="book">book - Submission is about a book not yet shown to meet notability guidelines</option>
 					<option value="event">event - Submission is about an event not yet shown to meet notability guidelines</option>
-					<option value="corp">corp - Submission is about a company or organization not yet shown to meet notability guidelines (aliases: inc, org)</option>
+					<option value="corp">corp - Submission is about a company or organization not yet shown to meet notability guidelines</option>
 					<option value="bio">bio - Submission is about a person not yet shown to meet notability guidelines</option>
 					<option value="nn">nn - Submission is about a topic not yet shown to meet general notability guidelines (be more specific if possible)</option>
 				</optgroup>
 				<optgroup label="Invalid submissions">
-					<option value="blank">blank - Submission is blank (alias: empty)</option>
+					<option value="blank">blank - Submission is blank</option>
 					<option value="cat">cat - Submission is a category request</option>
-					<option value="lang">lang - Submission is not in English (alias: notenglish)</option>
+					<option value="lang">lang - Submission is not in English</option>
 					<option value="test">test - Submission appears to be a test edit</option>
 					<option value="redirect">redirect - Submission is a redirect request</option>
 				</optgroup>
@@ -219,29 +219,29 @@
 					<option value="blp">blp - BLP contains unsourced, possibly defamatory claims (AGF and wait for sources)</option>
 				</optgroup>
 				<optgroup label="Submission content">
-					<option value="cv">cv - Submission is a copyright violation (alias: cv-n)</option>
-					<option value="v">v - Submission is improperly sourced (aliases: source, rs)</option>
+					<option value="cv">cv - Submission is a copyright violation</option>
+					<option value="v">v - Submission is improperly sourced</option>
 					<option value="not">not - Submission fails [[Wikipedia:What Wikipedia is not]]</option>
-					<option value="news">news - Submission appears to be a news story of a single event (alias: oneevent)</option>
-					<option value="dict">dict - Submission is a dictionary definition (alias: d)</option>
+					<option value="news">news - Submission appears to be a news story of a single event</option>
+					<option value="dict">dict - Submission is a dictionary definition</option>
 					<option value="plot">plot - Submission consists mostly of a plot summary</option>
 					<option value="joke">joke - Submission appears to be a joke or hoax</option>
 				</optgroup>
 				<optgroup label="Prose issues">
 					<option value="essay">essay - Submission reads like an essay</option>
 					<option value="npov">npov - Submission is not written in a formal, neutral encyclopedic tone</option>
-					<option value="adv">adv - Submission reads like an advertisement (aliases: advert, spam)</option>
+					<option value="adv">adv - Submission reads like an advertisement</option>
 					<option value="resume">resume - Submission reads like a résumé</option>
-					<option value="ai">ai - Submission appears to be a large language model output (alias: llm)</option>
+					<option value="ai">ai - Submission appears to be a large language model output</option>
 				</optgroup>
 				<optgroup label="Duplicate articles">
 					<option value="exists">exists - Submission is duplicated by another article already in mainspace</option>
-					<option value="dup">dup - Submission is a duplicate of another existing submission (alias: duplicate)</option>
+					<option value="dup">dup - Submission is a duplicate of another existing submission</option>
 				</optgroup>
 				<optgroup label="Other">
 					<option value="reason">custom - Enter decline reason in the box below</option>
 					<option value="context">context - Submission provides insufficient context</option>
-					<option value="mergeto">mergeto - Submission should be merged into an existing article (alias: merge)</option>
+					<option value="mergeto">mergeto - Submission should be merged into an existing article</option>
 				</optgroup>
 			</select>
 


### PR DESCRIPTION
The approach used made edit summaries longer and a bit cluttered. Someone mentioned it on my user talk at https://en.wikipedia.org/wiki/User_talk:Novem_Linguae#(aliases%3A_inc%2C_org) and I agree with them.

The ticket #439 can be re-opened, and a different approach to solve it can be used.

Related #436