### PR TITLE
Fix placeholder text parameter

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1938,7 +1938,7 @@
 
 			// Set up jquery.chosen for the decline reason
 			$afch.find( '#declineReason' ).chosen( {
-				placeholder_text_single: 'Select a decline reason...',
+				placeholder_text_multiple: 'Select one or more decline reasons...',
 				no_results_text: 'Whoops, no reasons matched your search. Type "custom" to add a custom rationale instead.',
 				search_contains: true,
 				inherit_select_classes: true,
@@ -1947,7 +1947,7 @@
 
 			// Set up jquery.chosen for the reject reason
 			$afch.find( '#rejectReason' ).chosen( {
-				placeholder_text_single: 'Select a reject reason...',
+				placeholder_text_multiple: 'Select one or more reject reasons...',
 				search_contains: true,
 				inherit_select_classes: true,
 				max_selected_options: 2


### PR DESCRIPTION
The given jquery.chosen parameter `placeholder_text_single` wasn't read, as the element used was a multi-select one, leading to the default placeholder text being used instead. I changed it to `placeholder_text_multiple` and adjusted the text to make it clear that multiple decline reasons can picked.