### PR TITLE
Add colour variable for background (dark mode compatability)

### DIFF
--- a/src/less/general.less
+++ b/src/less/general.less
@@ -14,6 +14,9 @@
 @blue: #0074D9;
 @red: #FF4136;
 
+/*Dark mode variable colours*/
+@darkmodeblack: var(--background-color-base);/* White in light mode*/
+
 /* General styles */
 
 .hidden {
@@ -49,6 +52,7 @@ div.gradient-button, .gradient-button {
 	-webkit-user-select: none;
 	user-select: none;
 	transition: box-shadow .1s ease-in-out;
+	color: @sexyblack;
 
 	&:hover {
 		text-decoration: none;

--- a/src/less/submissions.less
+++ b/src/less/submissions.less
@@ -95,7 +95,7 @@
 	}
 
 	.content {
-		background-color: @white;
+		background-color: @darkmodeblack;
 		padding: 10px;
 	}
 


### PR DESCRIPTION
Hey everyone! I recently started reviewing AfCs and noticed the script's interface is unreadable when using dark mode.

This change adds the Codex's colour variable for backgrounds (dark in dark mode and light in light mode), which I've applied to the interface's background to make the text readable (and not blindingly bright to dark mode users).

I also added a colour variable to the buttons to fix white text on a grey or yellow button being unreadable.

Ideally other changes would be made to things like the WikiProject select menu and category menu to make those dark too, but I thought I'd PR this quickly so it's at least usable to dark mode users.

Edit: relates to issue #382 