### PR TITLE
New AFC decline comments

### DIFF
--- a/src/templates/tpl-submissions.html
+++ b/src/templates/tpl-submissions.html
@@ -211,7 +211,7 @@
 					<option value="astro">astro - Submission is about an astronomical object not yet shown to meet notability guidelines</option>
 					<option value="number">number - Submission is about a number not yet shown to meet notability guidelines</option>
 					<option value="school">school - Submission is about a school not yet shown to meet notability guidelines</option>
-					<option value="list">list - Submission is a list not yet shown to meet inclusion criteria</option>
+					<option value="list">list - Submission is a list not yet shown to meet notability guidelines</option>
 					<option value="nn">nn - Submission is about a topic not yet shown to meet general notability guidelines (be more specific if possible)</option>
 				</optgroup>
 				<optgroup label="Invalid submissions">


### PR DESCRIPTION
AFC contributors [recently overhauled all the AFC templates](https://en.wikipedia.org/wiki/Wikipedia_talk:WikiProject_Articles_for_creation#Overhaul_of_the_AfC_templates), and have created a number of new decline rationale that have been implemented at [(https://en.wikipedia.org/wiki/Template:AfC_submission/comments)], which now just need adding to AFCH.