### PR TITLE
Fix #453 (teahouse invitation on reject)

### DIFF
--- a/src/less/general.less
+++ b/src/less/general.less
@@ -20,6 +20,10 @@
 	display: none !important;
 }
 
+.hidden2 {
+	display: none !important;
+}
+
 .centered {
 	text-align: center;
 }

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -2064,7 +2064,7 @@
 
 				// If a reason has been specified, show the textarea, notify
 				// option, and the submit form button
-				$afch.find( '#declineTextarea' ).add( '#notifyWrapper' ).add( '#afchSubmitForm' )
+				$afch.find( '#declineTextarea' ).add( '#declineNotifyWrapper' ).add( '#afchSubmitForm' )
 					.toggleClass( 'hidden', !reason || !reason.length )
 					.on( 'keyup', mw.util.debounce( 500, () => {
 						previewComment( $( '#declineTextarea' ), $( '#declineInputPreview' ) );
@@ -2077,7 +2077,7 @@
 
 				// If a reason has been specified, show the textarea, notify
 				// option, and the submit form button
-				$afch.find( '#rejectTextarea' ).add( '#notifyWrapper' ).add( '#afchSubmitForm' )
+				$afch.find( '#rejectTextarea' ).add( '#rejectNotifyWrapper' ).add( '#afchSubmitForm' )
 					.toggleClass( 'hidden', !reason || !reason.length )
 					.on( 'keyup', mw.util.debounce( 500, () => {
 						previewComment( $( '#rejectTextarea' ), $( '#rejectInputPreview' ) );
@@ -2114,6 +2114,8 @@
 				$afch.find( '#rejectReasonWrapper' ).toggleClass( 'hidden', declineOrReject === 'decline' );
 				$afch.find( '#declineInputWrapper' ).toggleClass( 'hidden', declineOrReject === 'reject' );
 				$afch.find( '#rejectInputWrapper' ).toggleClass( 'hidden', declineOrReject === 'decline' );
+				$afch.find( '#declineNotifyWrapper' ).toggleClass( 'hidden2', declineOrReject === 'reject' );
+				$afch.find( '#rejectNotifyWrapper' ).toggleClass( 'hidden2', declineOrReject === 'decline' );
 			} );
 		} ); // End loadView callback
 
@@ -2592,7 +2594,7 @@
 		if ( data.notifyUser ) {
 			afchSubmission.getSubmitter().done( ( submitter ) => {
 				const userTalk = new AFCH.Page( ( new mw.Title( submitter, 3 ) ).getPrefixedText() ),
-					shouldTeahouse = data.inviteToTeahouse ? $.Deferred() : false;
+					shouldTeahouse = data.inviteToTeahouse && isDecline ? $.Deferred() : false;
 
 				// Check categories on the page to ensure that if the user has already been
 				// invited to the Teahouse, we don't invite them again.

--- a/src/templates/tpl-submissions.html
+++ b/src/templates/tpl-submissions.html
@@ -308,7 +308,7 @@
 			<div id="rejectInputPreview"></div>
 		</div>
 
-		<div id="notifyWrapper" class="hidden">
+		<div id="declineNotifyWrapper" class="hidden">
 			<div class="afch-option">
 				<input type="checkbox" id="notifyUser" class="afch-input" checked/>
 				<label for="notifyUser" class="afch-label">Notify submitter</label>
@@ -316,6 +316,13 @@
 			<div class="afch-option">
 				<input type="checkbox" id="inviteToTeahouse" class="afch-input" checked/>
 				<label for="inviteToTeahouse" class="afch-label">Invite submitter to Teahouse <small>(if they haven't been invited yet)</small></label>
+			</div>
+		</div>
+
+		<div id="rejectNotifyWrapper" class="hidden">
+			<div class="afch-option">
+				<input type="checkbox" id="notifyUser" class="afch-input" checked/>
+				<label for="notifyUser" class="afch-label">Notify submitter</label>
 			</div>
 		</div>
 


### PR DESCRIPTION
I added hidden2 class because there may be two separate reasons `#rejectNotifyWrapper`/`#declineNotifyWrapper` may be hidden, either because the other decline option is selected or the user has not typed anything in the text area.

Another solution would be to store a Set() of reasons to hide the element and check if the set is empty, but I'm not sure if it's better.