### PR TITLE
Additional reject options

### DIFF
--- a/src/templates/tpl-submissions.html
+++ b/src/templates/tpl-submissions.html
@@ -234,7 +234,6 @@
 					<option value="news">news - Submission appears to be a news story of a single event</option>
 					<option value="dict">dict - Submission is a dictionary definition</option>
 					<option value="plot">plot - Submission consists mostly of a plot summary</option>
-					<option value="joke">joke - Submission appears to be a joke or hoax</option>
 					<option value="ecr">ecr - Submission is a contentious topic with an editing restriction</option>
 				</optgroup>
 				<optgroup label="Prose issues">
@@ -265,6 +264,8 @@
 			<select id="rejectReason" class="afch-input text-left" multiple="multiple">
 				<option value=""></option>
 				<option value="n">n - Topic is not notable</option>
+				<option value="j">j - Topic is a joke or hoax</option>
+				<option value="blp">blp - Topic is an attack page</option>
 				<option value="e">e - Topic is contrary to the purpose of Wikipedia</option>
 			</select>
 		</div>

--- a/src/templates/tpl-submissions.html
+++ b/src/templates/tpl-submissions.html
@@ -234,6 +234,7 @@
 					<option value="news">news - Submission appears to be a news story of a single event</option>
 					<option value="dict">dict - Submission is a dictionary definition</option>
 					<option value="plot">plot - Submission consists mostly of a plot summary</option>
+					<option value="joke">joke - Submission appears to be a joke or hoax</option>
 					<option value="ecr">ecr - Submission is a contentious topic with an editing restriction</option>
 				</optgroup>
 				<optgroup label="Prose issues">


### PR DESCRIPTION
Adds two new additional reject options; blp & joke/hoax.

Removes joke/hoax from the decline list.

Related edit request for the template is at (https://en.wikipedia.org/wiki/Template_talk:AfC_submission#Edit_request_3_April_2026)