### PR TITLE
tests: move scaffolding to jest.config.js and jest.setup.js

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+/* eslint-env node */
+
+module.exports = {
+	setupFilesAfterEnv: [ '<rootDir>/jest.setup.js' ],
+	testEnvironment: 'jsdom',
+	testMatch: [
+		'**/tests/**/test-*.[jt]s?(x)',
+		'**/?(*.)+(spec|test).[jt]s?(x)'
+	]
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -31,7 +31,7 @@ const setPageTitle = function ( title ) {
 resetToAFCApplicablePage = function () {
 	resetToBase();
 	setPageTitle( 'Draft:Foo' );
-	require( './../src/afch.js' );
+	require( './src/afch.js' );
 };
 
 inUnitTestEnvironment = true;
@@ -62,3 +62,8 @@ mw.loader = {
 };
 
 resetToBase();
+
+resetToAFCApplicablePage();
+
+require( './src/modules/core.js' );
+require( './src/modules/submissions.js' );

--- a/package.json
+++ b/package.json
@@ -35,12 +35,5 @@
     "jquery": "^3.6.0",
     "mwn": "^3.0.1",
     "simple-git": "^3.28.0"
-  },
-  "jest": {
-    "testEnvironment": "jsdom",
-    "testMatch": [
-      "**/tests/**/test-*.[jt]s?(x)",
-      "**/?(*.)+(spec|test).[jt]s?(x)"
-    ]
   }
 }

--- a/tests/test-core.js
+++ b/tests/test-core.js
@@ -5,21 +5,10 @@
 /* eslint-env jest */
 /* eslint-disable indent, quotes */
 
-require( './scaffold.js' );
-
-resetToAFCApplicablePage();
-
-require( './../src/modules/core.js' );
-
-// It's always good to start simple :)
 describe( 'AFCH', () => {
 	it( 'is an object', () => {
 		expect( typeof AFCH ).toBe( 'object' );
 	} );
-} );
-
-describe( 'AFCH.Page', () => {
-	// FIXME...
 } );
 
 describe( 'AFCH.removeEmptySectionAtEnd', () => {

--- a/tests/test-submissions.js
+++ b/tests/test-submissions.js
@@ -4,14 +4,6 @@
 
 /* eslint-env jest */
 
-require( './scaffold.js' );
-
-resetToAFCApplicablePage();
-
-require( './../src/modules/core.js' );
-require( './../src/modules/submissions.js' );
-
-// It's always good to start simple :)
 describe( 'AFCH', () => {
 	it( 'is an object', () => {
 		expect( typeof AFCH ).toBe( 'object' );


### PR DESCRIPTION
Why
* standard places for Jest config in MediaWiki repos

What
* create jest.config.js
* create jest.setup.js
* delete tests/scaffold.js
* modify tops of various test files