### PR TITLE
Decline list tidy up

### DIFF
--- a/src/templates/tpl-submissions.html
+++ b/src/templates/tpl-submissions.html
@@ -194,64 +194,64 @@
 			<select id="declineReason" class="afch-input text-left" multiple="multiple">
 				<option value=""></option>
 				<optgroup label="Notability">
-					<option value="neo">neo - Submission is about a neologism not yet shown to meet notability guidelines</option>
-					<option value="web">web - Submission is about web content not yet shown to meet notability guidelines</option>
-					<option value="prof">prof - Submission is about a professor not yet shown to meet notability guidelines</option>
-					<option value="athlete">athlete - Submission is about an athlete not yet shown to meet notability guidelines</option>
-					<option value="music">music - Submission is about a musician or musical work not yet shown to meet notability guidelines</option>
-					<option value="film">film - Submission is about a film not yet shown to meet notability guidelines</option>
-					<option value="book">book - Submission is about a book not yet shown to meet notability guidelines</option>
-					<option value="event">event - Submission is about an event not yet shown to meet notability guidelines</option>
-					<option value="corp">corp - Submission is about a company or organization not yet shown to meet notability guidelines</option>
-					<option value="bio">bio - Submission is about a person not yet shown to meet notability guidelines</option>
-					<option value="creative">creative - Submission is about a creative professional not yet shown to meet notability guidelines</option>
-					<option value="med">med - Submission is about a medical or health claim not yet shown to meet notability guidelines</option>
-					<option value="geo">geo - Submission is about a geographic feature not yet shown to meet notability guidelines</option>
-					<option value="species">species - Submission is about a species not yet shown to meet notability guidelines</option>
 					<option value="astro">astro - Submission is about an astronomical object not yet shown to meet notability guidelines</option>
-					<option value="number">number - Submission is about a number not yet shown to meet notability guidelines</option>
-					<option value="school">school - Submission is about a school not yet shown to meet notability guidelines</option>
+					<option value="athlete">athlete - Submission is about an athlete not yet shown to meet notability guidelines</option>
+					<option value="bio">bio - Submission is about a person not yet shown to meet notability guidelines</option>
+					<option value="book">book - Submission is about a book not yet shown to meet notability guidelines</option>
+					<option value="corp">corp - Submission is about a company or organization not yet shown to meet notability guidelines</option>
+					<option value="creative">creative - Submission is about a creative professional not yet shown to meet notability guidelines</option>
+					<option value="event">event - Submission is about an event not yet shown to meet notability guidelines</option>
+					<option value="film">film - Submission is about a film not yet shown to meet notability guidelines</option>
+					<option value="geo">geo - Submission is about a geographic feature not yet shown to meet notability guidelines</option>
 					<option value="list">list - Submission is a list not yet shown to meet notability guidelines</option>
+					<option value="music">music - Submission is about a musician or musical work not yet shown to meet notability guidelines</option>
+					<option value="neo">neo - Submission is about a neologism not yet shown to meet notability guidelines</option>
+					<option value="number">number - Submission is about a number not yet shown to meet notability guidelines</option>
+					<option value="prof">prof - Submission is about a professor not yet shown to meet notability guidelines</option>					
+					<option value="school">school - Submission is about a school not yet shown to meet notability guidelines</option>
+					<option value="species">species - Submission is about a species not yet shown to meet notability guidelines</option>
+					<option value="web">web - Submission is about web content not yet shown to meet notability guidelines</option>
 					<option value="nn">nn - Submission is about a topic not yet shown to meet general notability guidelines (be more specific if possible)</option>
+				</optgroup>
+				<optgroup label="Verifiability">
+					<option value="ns">nosource - Submission contains no sources or inline citations</option>
+					<option value="v">v - Submission lacks sufficient sources to verify content</option>
+					<option value="ilc">ilc - Submission is a BLP that does not meet minimum inline citation requirements</option>					
+					<option value="med">med - Submission is about a medical or health claim that lacks sufficient sources</option>
 				</optgroup>
 				<optgroup label="Invalid submissions">
 					<option value="blank">blank - Submission is blank</option>
 					<option value="cat">cat - Submission is a category request</option>
 					<option value="lang">lang - Submission is not in English</option>
-					<option value="test">test - Submission appears to be a test edit</option>
 					<option value="redirect">redirect - Submission is a redirect request</option>
+					<option value="test">test - Submission appears to be a test edit</option>
 				</optgroup>
-				<optgroup label="BLP &amp; vandalism">
-					<option value="van">van - Submission is vandalism, a negative unsourced BLP, or an attack page</option>
-					<option value="ilc">ilc - Submission is a BLP that does not meet minimum inline citation requirements</option>
+				<optgroup label="Content issues">
+					<option value="ai">ai - Submission appears to be a large language model output</option>
 					<option value="blp">blp - BLP contains unsourced, possibly defamatory claims (AGF and wait for sources)</option>
-				</optgroup>
-				<optgroup label="Submission content">
 					<option value="cv">cv - Submission is a copyright violation</option>
-					<option value="v">v - Submission is improperly sourced</option>
-					<option value="ns">nosource - Submission contains no sources or inline citations</option>
-					<option value="not">not - Submission fails [[Wikipedia:What Wikipedia is not]]</option>
-					<option value="news">news - Submission appears to be a news story of a single event</option>
+					<option value="context">context - Submission provides insufficient context</option>
 					<option value="dict">dict - Submission is a dictionary definition</option>
-					<option value="plot">plot - Submission consists mostly of a plot summary</option>
-					<option value="joke">joke - Submission appears to be a joke or hoax</option>
 					<option value="ecr">ecr - Submission is a contentious topic with an editing restriction</option>
+					<option value="joke">joke - Submission appears to be a joke or hoax</option>
+					<option value="news">news - Submission appears to be a news story of a single event</option>
+					<option value="not">not - Submission fails [[Wikipedia:What Wikipedia is not]]</option>
+					<option value="plot">plot - Submission consists mostly of a plot summary</option>
+					<option value="van">van - Submission is vandalism, a negative unsourced BLP, or an attack page</option>
 				</optgroup>
 				<optgroup label="Prose issues">
+					<option value="adv">adv - Submission reads like an advertisement</option>
 					<option value="essay">essay - Submission reads like an essay</option>
 					<option value="npov">npov - Submission is not written in a formal, neutral encyclopedic tone</option>
-					<option value="adv">adv - Submission reads like an advertisement</option>
 					<option value="resume">resume - Submission reads like a résumé</option>
-					<option value="ai">ai - Submission appears to be a large language model output</option>
 				</optgroup>
 				<optgroup label="Duplicate articles">
 					<option value="exists">exists - Submission is duplicated by another article already in mainspace</option>
-					<option value="dup">dup - Submission is a duplicate of another existing submission</option>
+					<option value="mergeto">mergeto - Submission should be merged into an existing article</option>					
+					<option value="dup">dup - Submission is a duplicate of another AfC draft submission</option>
 				</optgroup>
 				<optgroup label="Other">
 					<option value="reason">custom - Enter decline reason in the box below</option>
-					<option value="context">context - Submission provides insufficient context</option>
-					<option value="mergeto">mergeto - Submission should be merged into an existing article</option>
 				</optgroup>
 			</select>
 


### PR DESCRIPTION
Nothing major, just tidying up the list of decline templates for ease of use and to align closer with the workflow at [WP:AFCPURPOSE](https://en.wikipedia.org/w/index.php?title=Wikipedia:AFCPURPOSE), including: 
• Alphabetising the order of Notability and other declines 
• Recategorising / regrouping other declines (e.g. grouping all the verifiability-related declines under one heading)

Changes can be viewed in my sandbox at [Special:Permalink/1351779542](https://en.wikipedia.org/w/index.php?title=User:Nil_NZ/sandbox&oldid=1351779542)